### PR TITLE
Case Study: Chrome V8 Type Confusion (CVE-2022-3723)

### DIFF
--- a/javascript/chrome-v8-type-confusion-yagnapriya.md
+++ b/javascript/chrome-v8-type-confusion-yagnapriya.md
@@ -1,0 +1,158 @@
+Introduction
+
+Google Chrome is one of the most widely used browsers in the world, and its security depends heavily on the correctness of the V8 JavaScript engine, which executes untrusted JavaScript from billions of websites every day. V8 uses a combination of interpretation, Just-In-Time (JIT) compilation, and speculative optimization to improve performance. Because JavaScript is dynamically typed, V8 must constantly infer and validate types during execution.
+
+CVE-2022-3723 is a type confusion vulnerability discovered by Avast security researchers and was actively exploited in the wild. Type confusion occurs when software incorrectly assumes the type of a value or object, causing memory to be interpreted in an unsafe or unintended way. In a complex JIT environment like V8, this can lead to memory corruption and arbitrary code execution.
+
+This case study explains how the vulnerability occurred, why it is dangerous, and what systemic lessons developers can apply when designing high-performance engines.
+
+Software
+
+The V8 engine includes several major components:
+
+Ignition – a bytecode interpreter
+
+TurboFan – an optimizing JIT compiler
+
+Inline Caches (ICs) – record object shapes to speed up property access
+
+Speculative Optimization – predicts types to generate faster machine code
+
+V8 achieves performance by making speculative assumptions about JavaScript values. For example, if a function repeatedly sees a variable behave like a number, TurboFan optimizes future executions by treating it as a number without rechecking the type.
+
+This speeds up execution but introduces a risk:
+
+If the optimizer’s assumption becomes false later, the generated machine code may perform unsafe operations on memory.
+
+This creates opportunities for type confusion—an extremely dangerous class of memory safety flaws.
+
+Weakness
+
+This vulnerability corresponds to two MITRE CWE entries:
+
+CWE-843: Access of Resource Using Incompatible Type
+
+Occurs when a resource is treated as the wrong internal type.
+V8 may treat a JavaScript object as a different representation than it really is.
+
+CWE-704: Incorrect Type Conversion or Cast
+
+Occurs when type conversion is performed without proper validation.
+In V8, speculative optimization incorrectly assumed a stable type, allowing unsafe casts.
+
+Both weaknesses apply directly to CVE-2022-3723 because the JIT compiler failed to re-validate assumptions, allowing memory to be misinterpreted.
+
+Vulnerability
+
+The root cause of CVE-2022-3723 was an incorrect type inference flaw inside V8’s optimized code paths.
+
+Under certain conditions:
+
+A JavaScript value repeatedly appears to have a stable type (e.g., a number).
+
+TurboFan speculatively optimizes the function using that assumption.
+
+The optimizer fails to enforce sufficient runtime type checks.
+
+Optimized machine code treats the value as a different internal type.
+
+An attacker can modify the program behavior so that V8 misinterprets memory. This leads to memory corruption inside Chrome’s JavaScript engine.
+
+Avast confirmed that this vulnerability was actively exploited by attackers.
+
+Exploit
+
+Attackers can craft JavaScript that:
+
+Trains the JIT compiler by repeatedly calling a function with predictable types.
+
+Causes V8 to optimize the function based on incorrect assumptions.
+
+Switches the type at the right moment to break the assumption.
+
+Causes the optimized machine code to operate on unexpected memory.
+
+This can result in:
+
+Out-of-bounds reads and writes
+
+Corruption of V8 heap objects
+
+Manipulation of engine internals
+
+Arbitrary code execution inside Chrome’s sandbox
+
+Because attackers had working exploits before the fix, this vulnerability is considered high-severity.
+
+Fix
+
+Google addressed the issue quickly. The fix involved:
+
+Strengthening runtime type checks
+
+Hardening optimization paths that handled unstable types
+
+Restricting over-aggressive speculative assumptions
+
+Improving debugging and test coverage for type transitions
+
+The fix was released in Chrome 107.0.5304.87 and credited Avast for discovering real-world exploitation.
+
+Prevention
+
+This vulnerability highlights important lessons for teams building JIT engines, interpreters, and dynamic language runtimes:
+
+1. Validate speculative assumptions
+
+Optimizations must always include fallback checks.
+
+2. Avoid unsafe type inference shortcuts
+
+Performance should not come at the cost of memory safety.
+
+3. Improve JIT-specific fuzzing
+
+Coverage-guided fuzzers (ClusterFuzz, jsfunfuzz) detect unstable type transitions.
+
+4. Limit excessive complexity in speculative paths
+
+Over-complexity increases the likelihood of subtle bugs.
+
+5. Use defense-in-depth
+
+Memory safety hardening (bounds checks, sandboxing, pointer tagging) reduces impact even when assumptions fail.
+
+Conclusion
+
+CVE-2022-3723 illustrates how subtle flaws in high-performance JIT engines can lead to severe security issues. A single incorrect type inference inside V8 enabled reliable, real-world exploitation.
+
+The vulnerability reinforces the need for:
+
+Safe speculative optimization
+
+Strong runtime validation
+
+Continuous fuzzing
+
+Conservative design for type-dependent optimizations
+
+Securing systems like V8 is critical because they execute untrusted code from billions of websites.
+
+References
+
+Google Chrome Security Advisory for CVE-2022-3723
+
+Chromium Release Notes (Chrome 107.0.5304.87)
+
+Avast Threat Intelligence Report
+
+V8 Documentation – https://v8.dev
+
+CVE Entry – https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3723
+
+Contributions
+
+This case study was authored by Harini Dodla as part of a secure coding course project.
+I confirm that this work is released under the Creative Commons CC-BY-4.0 license for use in MITRE’s Secure Coding Case Studies repository.
+
+GitHub Issue: https://github.com/mitre/secure-coding-case-studies/issues/30


### PR DESCRIPTION
This pull request submits a new secure coding case study on the Chrome V8 Type Confusion vulnerability (CVE-2022-3723).

The case study describes how incorrect type inference inside the V8 JavaScript engine leads to a type confusion condition, how attackers can exploit it, how Google patched it, and systemic secure coding lessons developers can apply.

Related GitHub Proposal Issue: #30
