### PR TITLE
Case Study: RCE Vulnerability in Apache NiFi 

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -40,22 +40,27 @@ Each case study should follow a consistent structure to ensure readability and l
 
 Each of the above sections is explained in detail below. Please try to follow the guidance as closely as possible.
 
+All case studies should be written using the Markdown markup language.
+
 ### _Title_
 
 - Keep it concise and descriptive.
 - Avoid overly technical or vague titles.
 - Typical title follows the following structure: *\<Weakness/Exploit Type\> In \<Software Name\>*
 - Most titles are between 4 and 6 words.
+- Title should be in all caps.
+- Use the first-level heading in Markdown by adding a single hash character (#) before the title.
 
-> Examples:
->
-> SQL Injection In Postgraas Server\
-> Code Injection In Searchor\
-> Cross-Site Scripting In OpenC3 COSMOS Server\
-> Improper Certificate Validation In Airflow
+Examples:
+
+> \# SQL INJECTION IN POSTGRAAS SERVER\
+> \# CODE INJECTION IN SEARCHOR\
+> \# CROSS-SITE SCRIPTING IN OPENC3 COSMOS SERVER\
+> \# IMPROPER CERTIFICATE VALIDATION IN AIRFLOW
 
 ### _Introduction_
 
+- Use the third-level heading in Markdown (three hash characters) for the section heading.
 - Briefly introduce the topic and explain why it is important.
 - Typical introductions are one paragraph in length.
   - First sentence or two introduces the issue and potential consequences.
@@ -63,13 +68,17 @@ Each of the above sections is explained in detail below. Please try to follow th
   - This is followed by a sentence introducing the software application
   - The final sentence talks about the scope of the case study.
 
-> Example:
->
+Example:
+
+> \#\#\# Introduction:
+> 
 > The use of a database to store information is fundamental to many applications. Unfortunately, if the commands to place or retrieve this information are not properly constructed, then an adversary could inappropriately alter or read the information. The underlying source code weakness that makes such attacks possible is annually one of the CWE Top 25 Most Dangerous Software Weaknesses. In 2023 such a vulnerability was disclosed in Blue Yonder postgraas_server. Postgraas offers basic create, read, update, and delete (CRUD) operations for complete PostgreSQL database instances via a simple representational state transfer (REST) application programming interface (API). This case study will look at that vulnerability, the mistake made by the developers, what it enabled an adversary to accomplish, and how the code was eventually corrected.
 
 ### _Software_
 
 - This section is used to identify the specific software that the case study is referencing.
+- Use the third-level heading in Markdown (three hash characters) for the section heading.
+- Use the **bold** style in Markdown (two astericks) for each field name.
 - Three different fields are expected.
 
 _Name_
@@ -77,45 +86,44 @@ _Name_
 - The name of the software in which the issue existed.
 - Include the vendor name if applicable. Do not include the version in this field.
 
-> Examples:
->
-> postgraas_server\
-> Apache Airflow
-
 _Language_
 
 - The source code language where the root cause weakness was made.
-
-> Examples:
->
-> Python\
-> JavaScript\
-> C\
-> C++\
-> Java\
-> Go
+- Examples are Python, JavaScript, C, C++, Java, Go
 
 _URL_
 
 - The URL where the software can be found.
 - For open source projects this is typically a source repository such as GitHub
 
-> Examples:
->
-> https<nolink>://github.com/blue-yonder/postgraas_server\
-> https<nolink>://github.com/apache/airflow
+Examples:
+
+> \#\#\# Software:
+> 
+> \*\*Name:\*\* postgraas_server\
+> \*\*Language:\*\* Python\
+> \*\*URL:\*\* https<nolink>://github.com/blue-yonder/postgraas_server
+
+> \#\#\# Software:
+> 
+> \*\*Name:\*\* Apache Airflow\
+> \*\*Language:\*\* C++\
+> \*\*URL:\*\* https<nolink>://github.com/apache/airflow
 
 ### _Weakness_
 
 - This section is used to introduce the type of code level mistake.
+- Use the third-level heading in Markdown (three hash characters) for the section heading.
 - List the relevant CWE identifier and name at the beginning of the section.
 - This is not the section to show the vulnerable code, but rather a place to summarize and explain the type of mistake. For example, if the issue is related to an SQL Injection exploit, then use weakness section to explain what improper neutralization is and how this can manipulated by an adversary.
 - Typically one to two paragraphs in length.
 - The use of generic code examples (i.e., not code the actual code from the vulnerable software, but rather generic code to demonstrate the weakness) is recommended when appropriate to help explain the type of weakness. Please see the section in this style guide related to displaying source code.
 - Do not refer to the real software in this section.
 
-> Example:
->
+Example:
+
+> \#\#\# Weakness:
+> >
 > CWE-89: Improper Neutralization of Special Elements Used in an SQL Command
 >
 > The weakness exists when software constructs all or part of an SQL command using externally influenced input that has been obtained from an upstream component, but the software does not neutralize (e.g., canonicalize, encode, escape, quote, validate) or incorrectly neutralizes special elements that could modify the intent of the SQL command.
@@ -125,6 +133,7 @@ _URL_
 ### _Vulnerability_
 
 - This section is used to describe the publicly disclosed vulnerability.
+- Use the third-level heading in Markdown (three hash characters) for the section heading.
 - List the relevant CVE identifier at the beginning of the section.
 - Next, provide any additional information necessary to introduce the specific real world software and what it is used for. Focus on information that is necessary for the reader to fully understand the vulnerability and its place within the software.
 - Then walk the reader through the actual vulnerable code in detail. Call out specific lines and show how the weakness exists. Avoid exploit details as these will go in the next section of the case study.
@@ -135,22 +144,27 @@ _URL_
 ### _Exploit_
 
 - This section is used to describe the how the vulnerability was (or could have been) exploited and what the consequences of the exploit were (or could have been).
+- Use the third-level heading in Markdown (three hash characters) for the section heading.
 - List the relevant CAPEC identifier and name at the beginning of the section.
 - Typically one to three paragraphs in length, but complex exploits may take longer to explain and step the reader through.
 - When applicable, include example inputs that were used to drive the exploit and show how those inputs took advantage of the weakness in the code. Such code inputs should be highlighted in the same manner as example source code.
 
-> Example:
+Example:
+
+> \#\#\# Exploit:
 >
 > To exploit this vulnerability an adversary must construct a GET or POST request that contains a crafted “next” parameter. This request would be directed to a web application that uses a vulnerable version of Jupyter Server. Such a request would be the GET URL crafted below:
 >
-    https://www.example.org/?next=https:///www.malicious_site.com
->This URL — maybe sent via an email to a target user — would appear to come from a trusted application and the target user may be comfortable following the URL for that reason.
+>    https://www.example.org/?next=https://www.malicious_site.com
+>
+> This URL — maybe sent via an email to a target user — would appear to come from a trusted application and the target user may be comfortable following the URL for that reason.
 >
 >Looking closer at the example URL, the value of the “next” parameter would not be compared to the allow_origin due to the lack of a netloc component, and would be passed directly to the redirect() call. The underlying Tornado Web Framework would process the redirect() call and send a response back to the user’s client with a 301 or 302 status code signaling the web client to connect to the malicious URL.
 
 ### _Fix_
 
 - This section is used to describe how the original weakness in the source code was fixed.
+- Use the third-level heading in Markdown (three hash characters) for the section heading.
 - Focus only on the changes that are relevant to the weakness being addressed by the case study.
 - Provide the fixed source code (see the Source Code section of this guidance) and walk the reader through the changes line by line.
 - This section can vary in length depending on how complex the fixed source code is and how many changes had to be made.
@@ -158,24 +172,35 @@ _URL_
 ### _Prevention_
 
 - This section is used to describe how to prevent similar weaknesses in the future.
+- Use the third-level heading in Markdown (three hash characters) for the section heading.
 - The objective is that a reader will have enough knowledge after reading this section to go implement the suggestions.
 - Include well-established secure coding practices that are most effective for this type of weakness.
 - Include ways to identify such weaknesses that may have been inadvertently made. This may involve a type of tool to assist and the analysis technique leveraged.
 - Try to relate each recommendation back to the case study and how it would have helped prevent the issue.
 - Typical prevention sections are a few paragraphs in length.
 
+Example:
+
+> \#\#\# Prevention:
+>
+> Static analysis tools that track taint from user-supplied sources to the SQL related sinks are effective in identifying places in source code where this type of mistake may have been made. Once identified, leverage parameterization to fix the issue. If the coding language being used does not support parameterization, then very precise data validation can help reduce the ability to provide meaningful exploit code to inject.
+
 ### _Conclusion_
 
+- Use the third-level heading in Markdown (three hash characters) for the section heading.
 - Provides a brief summary of the case study.
 - Typically one to two paragraphs in length.
 - Do not introduce any new information in the Conclusion.
 
-> Example:
+Example:
+
+> \#\#\# Conclusion:
 >
 > The addition of parameterization to the code improves the neutralization efforts and removes the weakness “Improper Neutralization of Special Elements Used in an SQL Command”. With the weakness resolved, user controlled input that reaches the execute() call no longer operates outside of the original intent of the SQL command.
 
 ### _References_
 
+- Use the third-level heading in Markdown (three hash characters) for the section heading.
 - Provide the name and URL of software project page or source repository.
 - Provide the name and URL of the CVE item.
 - Provide the name and URL of the CWE and CAPEC entries.
@@ -186,8 +211,10 @@ _URL_
 - If a foundational tutorial or best practice guide is available then provide a URL to this as well.
 - Do not list every article or guidance document that is available.
 
-> Examples:
->
+Example:
+
+> \#\#\# References:
+> 
 > Searchor Project Page: https://github.com/ArjunSharda/Searchor<br>
 > CVE-2018-25088 Entry: https://www.cve.org/CVERecord?id=CVE-2023-3364<br>
 > CWE-94 Entry: https://cwe.mitre.org/data/definitions/94.html<br>
@@ -201,11 +228,14 @@ _URL_
 
 ### _Contributions_
 
+- Use the third-level heading in Markdown (three hash characters) for the section heading.
 - Provides credit to those individuals who significantly contributed to the writing of the case study
 - Includes the original creator and any reviewer
 
-> Example:
->
+Example:
+
+> \#\#\# Contributions:
+> 
 > Originally created by Drew Buttner - The MITRE Corporation\
 > Reviewed by David Rothenberg - The MITRE Corporation
 


### PR DESCRIPTION
References Issue #5 

Provided a case-study on CVE-2023-34468 on an RCE vulnerability in Apache NiFi
    - The file is attached as `msccs-13.md` in the java category
    - This case study aims to fufill the following issue (https://github.com/mitre/secure-coding-case-studies/issues/5)