### PR TITLE
Add case study for CWE-787 in sudo (CVE-2021-3156)

### DIFF
--- a/c/secure-coding-case-study-cwe-787-cve-2021-3156.md
+++ b/c/secure-coding-case-study-cwe-787-cve-2021-3156.md
@@ -1,0 +1,213 @@
+# HEAP-BASED BUFFER OVERFLOW IN SUDO
+
+## Introduction
+
+Local privilege escalation flaws are especially dangerous since they have the capacity to turn a low-privileged foothold into a total system compromise. A common underlying reason is insecure memory handling where input controlled by an attacker influences writes outside of the intended memory boundaries. This vulnerability class continues to be listed in the CWE Top 25 together with underwrite mistakes and memory access beyond limits. A major case was discovered in January 2021 in `sudo`, the extensively used tool for managing privileges on Unix-like systems. This case study investigates CVE-2021-3156, sometimes known as "Baron Samedit", discusses in depth the coding mistake and the path of exploitation, and emphasizes real engineering techniques that could have prevented the vulnerability before publication.
+
+## Software
+
+**Name:** sudo  
+**Language:** C  
+**URL:** <https://github.com/sudo-project/sudo>
+
+## Weakness
+
+[CWE-787: Out-of-bounds Write](https://cwe.mitre.org/data/definitions/787.html)
+
+This vulnerability surfaces when software writes data outside the limits of an assigned buffer. In memory-unsafe languages like C, this can compromise adjacent heap metadata or application state, resulting in crashes, control-flow hijacking, or privilege escalation.
+Inconsistent assumptions between two components processing the same data differently is a common pattern. Under one set of circumstances, one component could verify or change input, but another component takes for granted that change always happened. If those assumptions differ, buffer sizing or boundary checks could become invalid for the real data being processed.
+Stopping the memory write is vital but not enough in this instance: Teams must also stop cross-component state inconsistencies (e.g., mode flags and parser states) that would undermine security assumptions.
+
+## Vulnerability
+
+[CVE-2021-3156](https://www.cve.org/CVERecord?id=CVE-2021-3156) - Published 26 January 2021
+
+The `sudo` advisory describes a heap-based buffer overflow exploitable by local users, including users not listed in `sudoers`, without needing user authentication. Affected versions included `1.7.7` through `1.7.10p9`, `1.8.2` through `1.8.31p2`, and `1.9.0` through `1.9.5p1`.
+
+The vulnerability depends on an interaction between argument parsing in the front-end and argument unescaping in the `sudoers` plugin:
+
+1. Front-end parsing in shell mode is intended to escape metacharacters.
+2. Then policy code unescapes these characters for logging or matching.
+3. An inconsistency in the mode-flag let an execution path where unescaping happened even when the anticipated escaping criteria were not met.
+4. Unescaping's trailing backslash feature allowed copying past intended bounds into a heap buffer.
+
+The vulnerable unescape logic in `plugins/sudoers/sudoers.c` (tag `SUDO_1_9_5p1`) is shown below.
+
+```diff
+vulnerable file: plugins/sudoers/sudoers.c
+
+ 952  /* set user_args */
+ 953  if (NewArgc > 1) {
+ ...
+ 958      for (size = 0, av = NewArgv + 1; *av; av++)
+ 959          size += strlen(*av) + 1;
+ 960      if (size == 0 || (user_args = malloc(size)) == NULL) {
+ ...
+ 964      if (ISSET(sudo_mode, MODE_SHELL|MODE_LOGIN_SHELL)) {
+ ...
+ 970          for (to = user_args, av = NewArgv + 1; (from = *av); av++) {
+ 971              while (*from) {
+-972                  if (from[0] == '\\' && !isspace((unsigned char)from[1]))
+-973                      from++;
+-974                  *to++ = *from++;
++972                  if (from[0] == '\\' && !isspace((unsigned char)from[1]))
++973                      from++;
++974                  *to++ = *from++;
+ 975              }
+ 976              *to++ = ' ';
+ 977          }
+ 978          *--to = '\0';
+```
+
+If an argument ended with a single backslash, the pointer increment path could advance through the null terminator and continue copying bytes not accounted for in the original allocation size calculation. This created a heap overflow primitive in `user_args`.
+
+The exploitability also depended on parser behavior in `src/parse_args.c` (tag `SUDO_1_9_5p1`) when invoked as `sudoedit`. In that path, mode handling differed from `sudo -e`, enabling problematic flag combinations.
+
+```diff
+vulnerable file: src/parse_args.c
+
+ 259  /* First, check to see if we were invoked as "sudoedit". */
+ 260  proglen = strlen(progname);
+ 261  if (proglen > 4 && strcmp(progname + proglen - 4, "edit") == 0) {
+ 262      progname = "sudoedit";
+ 263      mode = MODE_EDIT;
+ 264      sudo_settings[ARG_SUDOEDIT].value = "true";
+ 265  }
+ ...
+ 363  case 'e':
+ 364      if (mode && mode != MODE_EDIT)
+ 365          usage_excl();
+ 366      mode = MODE_EDIT;
+ 367      sudo_settings[ARG_SUDOEDIT].value = "true";
+ 368      valid_flags = MODE_NONINTERACTIVE;
+```
+
+The main engineering lesson is that this wasn't only a "single bad loop" fault. This was a multi-stage contradiction throughout parsing and policy logic, where presumptions regarding mode state and escaping grew incorrect.
+
+## Exploit
+
+[CAPEC-100: Overflow Buffers](https://capec.mitre.org/data/definitions/100.html)
+
+The advisory and research writeups demonstrate that an assailant may run `sudoedit` with shell-related flags and created trailing backslashes to cause heap corruption, then use environment variables and arguments to affect memory contents. Since this happened in a privileged executable environment, effective exploitation made root access possible.
+
+An indicative trigger used by researchers was:
+
+```
+sudoedit -s '\'
+```
+
+On vulnerable systems, this did not terminate with the patched usage-path behavior and could proceed into the vulnerable flow. More advanced proof-of-concept inputs used carefully chosen environment variables to influence adjacent heap data after overflow and achieve reliable privilege escalation.
+
+Operationally, this attack had high impact because `sudo` is ubiquitous and often installed by default. Even environments with strict remote perimeter controls remain exposed once a local foothold exists.
+
+## Fix
+
+The fix in `sudo 1.8.32` / `1.9.5p2` addressed both the parser inconsistency and the unsafe unescaping behavior.
+
+First, `parse_args.c` was corrected so `sudoedit` initialization uses edit-specific valid flags (same policy as `-e`) instead of inheriting broader defaults:
+
+```diff
+fixed file: src/parse_args.c
+
+ 262  /* First, check to see if we were invoked as "sudoedit". */
+ 263  proglen = strlen(progname);
+ 264  if (proglen > 4 && strcmp(progname + proglen - 4, "edit") == 0) {
+ 265      progname = "sudoedit";
+ 266      mode = MODE_EDIT;
+ 267      sudo_settings[ARG_SUDOEDIT].value = "true";
++268      valid_flags = EDIT_VALID_FLAGS;
+ 269  }
+ ...
+ 370  case 'e':
+ 371      if (mode && mode != MODE_EDIT)
+ 372          usage_excl();
+ 373      mode = MODE_EDIT;
+ 374      sudo_settings[ARG_SUDOEDIT].value = "true";
+-375      valid_flags = MODE_NONINTERACTIVE;
++375      valid_flags = EDIT_VALID_FLAGS;
+```
+
+Second, `sudoers.c` was hardened so unescaping only happens in run mode with shell mode, and bounds are checked while building `user_args`:
+
+```diff
+fixed file: plugins/sudoers/sudoers.c
+
+ 964  if (ISSET(sudo_mode, MODE_SHELL|MODE_LOGIN_SHELL) &&
++965      ISSET(sudo_mode, MODE_RUN)) {
+ ...
+ 972          while (*from) {
+-973              if (from[0] == '\\' && !isspace((unsigned char)from[1]))
+-974                  from++;
+-975              *to++ = *from++;
++973              if (from[0] == '\\' && from[1] != '\0' &&
++974                  !isspace((unsigned char)from[1])) {
++975                  from++;
++976              }
++977              if (size - (to - user_args) < 1) {
++978                  sudo_warnx(U_("internal error, %s overflow"), __func__);
++979                  debug_return_int(NOT_FOUND_ERROR);
++980              }
++981              *to++ = *from++;
+ 982          }
++983          if (size - (to - user_args) < 1) {
++984              sudo_warnx(U_("internal error, %s overflow"), __func__);
++985              debug_return_int(NOT_FOUND_ERROR);
++986          }
+ 987          *to++ = ' ';
+```
+
+These changes prevent the vulnerable state combination and remove unsafe assumptions in memory writes. Even if one condition were missed, the added bounds checks provide defense in depth.
+
+## Prevention
+
+This kind of flaw can only be avoided by structural checks, not just by "being careful with pointers". The following techniques directly relate to the existence of CVE-2021-3156 and how it might have been avoided prior to publication.
+
+First, implement cross-module security invariants as explicit contracts and testable assertions. Here one component assumed that data was processed as if that invariant always held, but another component assumed that data was processed as if that invariant did not always hold. Define contracts like: "unescape path is reachable only when `MODE_RUN && MODE_SHELL` and inputs came from the escaping frontend path." In privileged/debug builds, encode those prerequisites as runtime assertions; for every entry point (such as `sudo`, `sudoedit`, `-e`, `-s`, `-i` combinations), encode them as unit tests. This makes previously hidden assumptions into legally binding regulations.
+
+Second, mandate a memory-safe string construction pattern for privileged C code. All loops that duplicate bytes that have been influenced by an attacker should adhere to a conventional safe primitive or macro pattern that executes a checked append on each write (or reserves and validates full bounds before copy). The hazardous copy loop would have been rejected during the review if ad hoc pointer arithmetic for security-critical argument assembly had been prohibited.
+
+Third, include bad test matrices that list the transitions between option-flag states, not just the execution of "happy path" commands. A rare combination of edge-case modes (`sudoedit` + shell flags) instead of a typical workflow made CVE-2021-3156 possible. A combinatorial test harness for parser states should verify that each mode consistently accepts only the intended flags and rejects all others. This is a cost-effective automated control with a significant return for CLI security.
+
+Fourth, use continuous fuzzing with sanitizers enabled on parser and argument rewrite pathways. Nightly, create `sudo` using the command line and environment variable inputs for all invocation aliases (`sudo`, `sudoedit`) and the option `-fsanitize=address,undefined`. Seed corpora should have big environment sets, trailing backslashes, and integrated null-like boundary patterns. The purpose of fuzzing with ASan support is to identify this sort of vulnerability as soon as possible.
+
+Fifth, use static analysis with unique rules designed to address privileged code patterns. Project-specific rules can detect hazardous constructs, such as (a) pointer increments conditioned on nearby byte checks, (b) writes to derived buffers without monotonic capacity accounting, and (c) divergent flag-validation paths for alias entrypoints, which are frequently inadequate on their own. Demanding "no new high-confidence memory write findings" as a merge gate significantly lowers risk.
+
+Sixth, use a defense-in-depth approach to handle conflicts between parser and policy. With usage/error rather than trying to recover, fail closed if front-end and plugin mode interpretations ever conflict. This idea is demonstrated by the constant behavior of `sudo`; strong privileged tools should treat uncertainty as dangerous and quit.
+
+Lastly, make sure to utilize a security review checklist for each release that deals with argument parsing or privilege boundaries. At a minimum, reviewers should be required to answer: (1) What are all attacker-controlled sources? (2) Where are all buffer size calculations? (3) Which assumptions cross component boundaries? (4) Which tests demonstrate that invalid mode combinations are rejected? This leads to consistent process quality, not heroism.
+
+## Conclusion
+
+CVE-2021-3156 in `sudo` demonstrates how high-impact privilege escalation can emerge from both low-level memory handling and higher-level state inconsistency between components. The fix succeeded because it addressed both dimensions: it constrained valid parser states and hardened unescape buffer writes.
+
+The broader lesson is that prevention must be systemic. Explicit invariants, checked copy patterns, state-combination tests, sanitizer-backed fuzzing, and fail-closed behavior for ambiguous states together provide strong protection against repeat vulnerabilities of this type.
+
+## References
+
+sudo Project Page: <https://www.sudo.ws/>
+
+sudo Source Repository: <https://github.com/sudo-project/sudo>
+
+CVE-2021-3156 Entry: <https://www.cve.org/CVERecord?id=CVE-2021-3156>
+
+NVD CVE-2021-3156 Detail: <https://nvd.nist.gov/vuln/detail/CVE-2021-3156>
+
+CWE-787 Entry: <https://cwe.mitre.org/data/definitions/787.html>
+
+CAPEC-100 Entry: <https://capec.mitre.org/data/definitions/100.html>
+
+sudo Security Advisory (unescape overflow): <https://www.sudo.ws/security/advisories/unescape_overflow/>
+
+Qualys Research Advisory: <https://www.qualys.com/2021/01/26/cve-2021-3156/baron-samedit-heap-based-overflow-sudo.txt>
+
+sudo Commit (valid_flags / sudoedit fix): <https://github.com/sudo-project/sudo/commit/b301b46b79c6e2a76d530fa36d05992e74952ee8>
+
+sudo Commit (unescape overflow fix): <https://github.com/sudo-project/sudo/commit/1f8638577d0c80a4ff864a2aad80a0d95488e9a8>
+
+## Contributions
+
+Created by Vinaya Mahajan and Shatakshi Rathore - George Mason University
+Reviewed by Prof. David Wheeler - George Mason University
+
+Copyright (c) 2026 Vinaya Mahajan and Shatakshi Rathore  
+This work is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)


### PR DESCRIPTION
## Summary
- Adds a new secure coding case study for CVE-2021-3156 (Baron Samedit) in `sudo` under `c/`.
- Explains the vulnerable and fixed code paths in `parse_args.c` and `sudoers.c`.
- Emphasizes systemic prevention practices and links supporting references.
- Related proposal issue: #57.

## Test plan
- [x] Confirmed file naming follows style guide (`secure-coding-case-study-cwe-787-cve-2021-3156.md`).
- [x] Confirmed required section order is present (Title -> Contributions).
- [x] Verified references include CVE/CWE/CAPEC, vendor advisory, and fix commits.
- [ ] Update teammate/reviewer placeholders if needed based on course team details.
