### PR TITLE
Add case study for CVE-2023-4863 in libwebp

### DIFF
--- a/c/secure-coding-case-study-cwe-787-cve-2023-4863.md
+++ b/c/secure-coding-case-study-cwe-787-cve-2023-4863.md
@@ -131,8 +131,9 @@ Technical Write-up (example): <https://tarlogic.com/blog/cve-2023-4863>
 
 ## Contributions
 
-Originally created by Vinaya Mahajan and Shatakshi Rathore - George Mason University
+Originally created by Vinaya Mahajan and Shatakshi Rathore - George Mason University  
 Reviewed by Professor David A. Wheeler - George Mason University  
 
 Copyright (c) 2026 Vinaya Mahajan and Shatakshi Rathore  
 This work is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)
+

--- a/c/secure-coding-case-study-cwe-787-cve-2023-4863.md
+++ b/c/secure-coding-case-study-cwe-787-cve-2023-4863.md
@@ -133,3 +133,6 @@ Technical Write-up (example): <https://tarlogic.com/blog/cve-2023-4863>
 
 Originally created by Vinaya Mahajan and Shatakshi Rathore  
 
+Copyright (c) 2026 Vinaya Mahajan and Shatakshi Rathore  
+This work is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)
+

--- a/c/secure-coding-case-study-cwe-787-cve-2023-4863.md
+++ b/c/secure-coding-case-study-cwe-787-cve-2023-4863.md
@@ -131,9 +131,10 @@ Technical Write-up (example): <https://tarlogic.com/blog/cve-2023-4863>
 
 ## Contributions
 
-Originally created by Vinaya Mahajan and Shatakshi Rathore  
+Originally created by Vinaya Mahajan and Shatakshi Rathore - George Mason University
 Reviewed by Professor David A. Wheeler - George Mason University  
 
 Copyright (c) 2026 Vinaya Mahajan and Shatakshi Rathore  
 This work is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)
+
 

--- a/c/secure-coding-case-study-cwe-787-cve-2023-4863.md
+++ b/c/secure-coding-case-study-cwe-787-cve-2023-4863.md
@@ -132,6 +132,7 @@ Technical Write-up (example): <https://tarlogic.com/blog/cve-2023-4863>
 ## Contributions
 
 Originally created by Vinaya Mahajan and Shatakshi Rathore  
+Reviewed by Professor David A. Wheeler - George Mason University  
 
 Copyright (c) 2026 Vinaya Mahajan and Shatakshi Rathore  
 This work is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)

--- a/c/secure-coding-case-study-cwe-787-cve-2023-4863.md
+++ b/c/secure-coding-case-study-cwe-787-cve-2023-4863.md
@@ -136,5 +136,3 @@ Reviewed by Professor David A. Wheeler - George Mason University
 
 Copyright (c) 2026 Vinaya Mahajan and Shatakshi Rathore  
 This work is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)
-
-

--- a/c/secure-coding-case-study-cwe-787-cve-2023-4863.md
+++ b/c/secure-coding-case-study-cwe-787-cve-2023-4863.md
@@ -1,0 +1,135 @@
+# OUT-OF-BOUNDS WRITE IN LIBWEBP
+
+## Introduction
+
+Image decoding is one of those “routine” features that ends up in a lot of places: web browsers, messaging apps, document viewers, and backend services that resize or transform uploads. When that decoding happens in memory-unsafe code (like C), a small mistake in a parser can turn into memory corruption. An out-of-bounds write is one of the most serious forms of memory corruption because it can crash a process and, under the right conditions, be turned into code execution. In September 2023, a widely exploited out-of-bounds write was disclosed in the WebP image codec library `libwebp`. This case study looks at CVE-2023-4863, the specific coding mistake that enabled it, how it was fixed upstream, and what practical engineering practices would make a similar bug much less likely to ship again.
+
+## Software
+
+**Name:** libwebp (WebP Codec)  
+**Language:** C  
+**URL:** <https://github.com/webmproject/libwebp>
+
+## Weakness
+
+[CWE-787: Out-of-bounds Write](https://cwe.mitre.org/data/definitions/787.html)
+
+An out-of-bounds write happens when software writes past the end (or before the beginning) of a buffer because it computed an index, pointer, or length incorrectly, or because it trusted a computed value without checking it. In C and C++, there is no built-in bounds checking for ordinary array and pointer operations, so the write “works” even when it targets memory that does not belong to the buffer.
+
+These weaknesses are common in parsers and decoders because the program is turning a compact input format into internal data structures using lots of derived values: counts, offsets, table sizes, and state transitions. If any of those derived values are inconsistent with the size of an allocation, an attacker may be able to push the code into writing beyond the allocated region. The most visible outcome is usually a crash, but out-of-bounds writes can also be exploitable depending on how the surrounding memory is laid out and what defenses are in place.
+
+## Vulnerability
+
+[CVE-2023-4863](https://www.cve.org/CVERecord?id=CVE-2023-4863) – Published 11 September 2023
+
+CVE-2023-4863 is a heap buffer overflow in `libwebp` that could be triggered by a crafted WebP image. The vulnerable code path was in the lossless WebP decoder’s Huffman table construction logic. At a high level, this code reads code-length information from the compressed bitstream, sorts symbols by length, and then expands that into lookup tables used during decoding.
+
+In `libwebp` 1.3.2 (and earlier), the table builder sorts symbols into a `sorted[]` array using an `offset[]` array indexed by code length. The logic below writes `symbol` into `sorted[offset[symbol_code_length]++]` without validating that the computed offset is still within `sorted[]`’s bounds:
+
+```diff
+vulnerable file: libwebp/src/utils/huffman_utils.c
+
+ 120:  // Sort symbols by length, by symbol order within each length.
+ 121:  for (symbol = 0; symbol < code_lengths_size; ++symbol) {
+ 122:    const int symbol_code_length = code_lengths[symbol];
+ 123:    if (code_lengths[symbol] > 0) {
+ 124:      if (sorted != NULL) {
+ 125:        sorted[offset[symbol_code_length]++] = symbol;
+ 126:      } else {
+ 127:        offset[symbol_code_length]++;
+ 128:      }
+ 129:    }
+ 130:  }
+```
+
+This `sorted[]` array is not “just” bookkeeping. It is the list of symbols that the rest of the table-building code consumes. If the offsets drift out of range, the write at line 125 can go past the end of `sorted[]`, corrupting adjacent memory on the heap. That corruption then feeds into later steps, because the decoder assumes `sorted[]` contains a valid ordering of symbols.
+
+Later in the same function, the decoder populates second-level Huffman tables by calling `ReplicateValue()` on a computed pointer into the decoding table:
+
+```diff
+vulnerable file: libwebp/src/utils/huffman_utils.c
+
+ 193:        if (root_table != NULL) {
+ 194:          code.bits = (uint8_t)(len - root_bits);
+ 195:          code.value = (uint16_t)sorted[symbol++];
+ 196:          ReplicateValue(&table[key >> root_bits], step, table_size, code);
+ 197:        }
+```
+
+By the time execution reaches this code, the decoder is repeatedly writing to memory based on values derived from the bitstream (which controls code lengths and thus table shape). In a component like an image decoder, the attacker’s “input” is the file itself, so a malformed WebP can influence how many entries the decoder thinks it must write and where those writes land. This is why the missing bounds enforcement in the earlier sorting step is so risky: it is in the middle of a pipeline that turns attacker-controlled structure into memory writes.
+
+## Exploit
+
+[CAPEC-100: Overflow Buffers](https://capec.mitre.org/data/definitions/100.html)
+
+To trigger this vulnerability, an attacker provides a crafted WebP file that drives the lossless decoder into building Huffman tables using inconsistent or adversarial code-length data. In practical terms, exploitation looks like “get the target to decode an image.” That could be a browser rendering a WebP image from a web page, or an application decoding an image preview during upload or display.
+
+Because this is memory corruption in a widely used native library, the impact spans from a crash (denial of service) to potential code execution depending on the environment (compiler hardening, sandboxing, heap layout, and exploit mitigations). CVE-2023-4863 was treated as a high-severity issue by downstream vendors and was listed by CISA as known to be exploited in the wild, which is a strong indicator that this was not a theoretical concern.
+
+## Fix
+
+`libwebp` fixed this issue by strengthening validation during Huffman table construction so that offsets and sizes are checked before writing into arrays. In `libwebp` 1.4.0, the sorting loop explicitly checks that the computed offset is within the bounds of `sorted[]` before writing:
+
+```diff
+fixed file: libwebp/src/utils/huffman_utils.c
+
+ 120:  // Sort symbols by length, by symbol order within each length.
+ 121:  for (symbol = 0; symbol < code_lengths_size; ++symbol) {
+ 122:    const int symbol_code_length = code_lengths[symbol];
+ 123:    if (code_lengths[symbol] > 0) {
+ 124:      if (sorted != NULL) {
+ 125:        if(offset[symbol_code_length] >= code_lengths_size) {
+ 126:            return 0;
+ 127:        }
+ 128:        sorted[offset[symbol_code_length]++] = symbol;
+ 129:      } else {
+ 130:        offset[symbol_code_length]++;
+ 131:      }
+ 132:    }
+ 133:  }
+```
+
+This check matters because it turns a silent memory corruption into a safe failure: once the code detects an impossible offset, it stops and returns an error instead of writing past the end of the heap allocation. The upstream fix series around this vulnerability also worked to validate table construction before committing to memory writes and to ensure allocation and table sizing match worst-case valid inputs, not only “well-behaved” or common inputs.
+
+## Prevention
+
+Out-of-bounds writes in native decoders are not prevented by “being careful,” because the code is complex and the input space is huge. The practical goal is to build an environment where (1) it is difficult to write past a buffer without the code noticing, (2) mistakes are caught automatically during development, and (3) if a bug still ships, it is harder to turn into a full compromise.
+
+Start by deciding where decoding is allowed to happen. If a memory-safe decoder is feasible for your product, using it removes whole categories of memory corruption. If you must decode in C/C++, treat image decoding as hostile input handling and isolate it. The strongest isolation is process separation with sandboxing and least privilege, so that a decoder bug does not automatically become a bug “in the whole application.”
+
+Next, make bounds explicit in the code, especially in table-building logic like this case study. Treat derived values (offsets, counts, and sizes) as untrusted until proven consistent with the allocations they are about to index. The fixed code adds a simple check before writing to `sorted[]`, but the broader principle is that every derived index used for a write should be checked against the array’s length, and every accumulator that “walks” an array should be proven to stop at the array boundary. Allocate based on validated worst-case bounds rather than “typical” inputs, and when an invariant fails, stop decoding instead of trying to continue.
+
+Then, make memory-safety testing part of the normal development workflow, not a one-time audit. For C/C++ parsers, sanitizer builds and fuzzing are two of the most reliable ways to catch out-of-bounds writes early. Run AddressSanitizer (ASan) and UndefinedBehaviorSanitizer (UBSan) in CI on decoder-heavy code paths, and continuously fuzz the decode surface with a coverage-guided fuzzer. When a crash is found, keep the reproducer as a regression test case so the bug does not return. These steps are effective precisely because they turn “maybe exploitable” silent corruption into a clear crash during testing.
+
+Finally, treat codec libraries as high-risk third-party dependencies and plan for rapid updates. Build an operational path to ship library updates quickly (automated rebuild and testing, staged rollout, and clear ownership), because even excellent engineering cannot prevent every vulnerability. When a vulnerability like CVE-2023-4863 is disclosed and exploited, reducing the time-to-patch is one of the most important controls you still have.
+
+Used together, these practices would have made it much harder for an out-of-bounds write like CVE-2023-4863 to ship unnoticed, and they would also reduce the consequences if a similar bug slipped through.
+
+## Conclusion
+
+CVE-2023-4863 is a good reminder that “boring” features like image decoding can become high-severity vulnerabilities when they sit on a native parsing surface used everywhere. The fix in `libwebp` tightened validation so that table-building stops instead of writing past a buffer. From a prevention standpoint, the most effective approach is not a single rule, but a set of practical defaults: isolate decoding, enforce bounds and invariants on derived indices, and continuously test the decoder with sanitizer-backed fuzzing so memory corruption fails fast during development rather than in production.
+
+## References
+
+libwebp Project Page: <https://github.com/webmproject/libwebp>
+
+CVE-2023-4863 Entry: <https://www.cve.org/CVERecord?id=CVE-2023-4863>
+
+NVD Vulnerability Report: <https://nvd.nist.gov/vuln/detail/CVE-2023-4863>
+
+CWE-787 Entry: <https://cwe.mitre.org/data/definitions/787.html>
+
+CAPEC-100 Entry: <https://capec.mitre.org/data/definitions/100.html>
+
+CISA Known Exploited Vulnerabilities Entry (CVE-2023-4863): <https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2023-4863>
+
+libwebp Fix Commit (OOB write in Huffman table build): <https://github.com/webmproject/libwebp/commit/902bc9190331343b2017211debcec8d2ab87e17a>
+
+oss-security Post (CVE-2023-4863 disclosure): <https://seclists.org/oss-sec/2023/q3/204>
+
+Technical Write-up (example): <https://tarlogic.com/blog/cve-2023-4863>
+
+## Contributions
+
+Originally created by Vinaya Mahajan and Shatakshi Rathore  
+

--- a/c/secure-coding-case-study-cwe-787-cve-2023-4863.md
+++ b/c/secure-coding-case-study-cwe-787-cve-2023-4863.md
@@ -132,7 +132,6 @@ Technical Write-up (example): <https://tarlogic.com/blog/cve-2023-4863>
 ## Contributions
 
 Originally created by Vinaya Mahajan and Shatakshi Rathore - George Mason University  
-Reviewed by Professor David A. Wheeler - George Mason University  
 
 Copyright (c) 2026 Vinaya Mahajan and Shatakshi Rathore  
 This work is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)


### PR DESCRIPTION
## Summary
- Adds a new secure coding case study for **CWE-787 (Out-of-bounds Write)** based on **CVE-2023-4863** in **libwebp**.
- Focuses on the vulnerable and fixed code around Huffman table construction and provides practical prevention guidance.

## Test plan
- N/A (documentation)

## Tracking
- Proposal issue: #80