### PR TITLE
Add case study for CVE-2021-23337 (lodash)

### DIFF
--- a/javascript/secure-coding-case-study-cwe-94-cve-2021-23337.md
+++ b/javascript/secure-coding-case-study-cwe-94-cve-2021-23337.md
@@ -1,0 +1,194 @@
+# CODE INJECTION IN LODASH
+
+## Introduction
+
+Template engines can become dangerous when they create executable code from strings and allow attacker-controlled input to influence that generated code. This type of weakness is called code injection, where data provided from outside the program changes the syntax or behavior of code that the program later executes. Code injection ranks among the CWE Top 25 Most Dangerous Software Weaknesses, reflecting how frequently this class of mistake leads to serious exploits. Lodash is a widely used JavaScript utility library that includes a template compilation function named `_.template()`. This case study examines CVE-2021-23337, a vulnerability in lodash where the `variable` option in `_.template()` was not validated before being inserted into generated JavaScript source code.
+
+## Software
+
+**Name:** lodash  
+**Language:** JavaScript  
+**URL:** <https://github.com/lodash/lodash>
+
+## Weakness
+
+[CWE-94: Improper Control of Generation of Code ('Code Injection')](https://cwe.mitre.org/data/definitions/94.html)
+
+The weakness occurs when software constructs a code segment using externally influenced input without properly neutralizing that input before execution. In a safe design, untrusted input should remain data. It should never be able to add new statements or change the structure of code the program executes. A classic example is passing user-controlled input into JavaScript's `Function()` constructor, which compiles a string directly into executable code:
+
+```
+var userInput = getInputFromRequest();
+var fn = Function('return ' + userInput);
+fn();
+```
+
+If an attacker controls `userInput`, they can inject arbitrary JavaScript. This is especially dangerous in server-side Node.js environments where injected code can access environment variables, the filesystem, and network resources.
+
+## Vulnerability
+
+[CVE-2021-23337](https://www.cve.org/CVERecord?id=CVE-2021-23337) – Published 15 February 2021
+
+Lodash's `_.template()` compiles template strings into reusable JavaScript functions. One of its options is `variable`, which sets the name of the data object the compiled function accepts. For example, `variable: 'data'` allows the template to reference `data.name`. The vulnerability existed because lodash embedded the `variable` option directly into generated JavaScript source without first checking whether the value was a safe identifier.
+
+```
+vulnerable file: lodash/lodash.js (v4.17.20)
+
+ 20    /** Error message constants. */
+ 21    var CORE_ERROR_TEXT = 'Unsupported core-js use. Try https://npms.io/search?q=ponyfill.',
+ 22        FUNC_ERROR_TEXT = 'Expected a function';
+ ...
+ 14865    var variable = hasOwnProperty.call(options, 'variable') && options.variable;
+ 14866    if (!variable) {
+ 14867      source = 'with (obj) {\n' + source + '\n}\n';
+ 14868    }
+ ...
+ 14875    source = 'function(' + (variable || 'obj') + ') {\n' +
+ 14876      (variable
+ 14877        ? ''
+ 14878        : 'obj || (obj = {});\n'
+ 14879      ) +
+ 14880      "var __t, __p = ''" +
+ 14891      'return __p\n}';
+ ...
+ 14893    var result = attempt(function() {
+ 14894      return Function(importsKeys, sourceURL + 'return ' + source)
+ 14895        .apply(undefined, importsValues);
+ 14896    });
+```
+
+Line 14865 reads `variable` from caller-supplied options with no validation. Line 14875 inserts that value directly into the function signature string. If `variable` is a normal identifier like `data`, the result is a safe `function(data) {`. However, if `variable` contains syntax characters, those characters alter the generated function body. Lines 14893–14895 are the sink: the assembled string is passed to `Function()`, which compiles it as JavaScript. The full taint flow is:
+
+```
+options.variable -> variable (line 14865)
+    -> generated source string (line 14875)
+    -> Function(importsKeys, 'return ' + source) (line 14894)
+    -> executed JavaScript
+```
+
+## Exploit
+
+[CAPEC-242: Code Injection](https://capec.mitre.org/data/definitions/242.html)
+
+To exploit this vulnerability, an attacker needed a server-side Node.js application that passed attacker-controlled input into the `variable` option of `_.template()`. The following proof-of-concept caused arbitrary JavaScript to execute at template compilation time:
+
+```
+var _ = require('lodash');
+_.template('', {
+  variable: '){console.log(process.env)}; with(obj'
+})();
+```
+
+The crafted `variable` value uses `)` to close the function parameter list early at line 14875, then injects a new JavaScript statement (`console.log(process.env)`), and finally reopens a valid syntax context with `with(obj`. When lodash builds `function(` + variable + `) {`, the result is a malformed function definition that embeds the attacker's code. In a real application this could expose secrets stored in environment variables, enable file system access, or achieve full remote code execution with the permissions of the Node.js process.
+
+## Fix
+
+The fix validated the `variable` option before it could reach the `Function()` constructor. Three changes were made in lodash v4.17.21. First, a new error message constant was added at line 23:
+
+```diff
+fixed file: lodash/lodash.js
+
+ 20    /** Error message constants. */
+ 21    var CORE_ERROR_TEXT = 'Unsupported core-js use. Try https://npms.io/search?q=ponyfill.',
+-22        FUNC_ERROR_TEXT = 'Expected a function';
++22        FUNC_ERROR_TEXT = 'Expected a function',
++23        INVALID_TEMPL_VAR_ERROR_TEXT = 'Invalid `variable` option passed into `_.template`';
+```
+
+Second, a regular expression was introduced at line 179 that explicitly forbids characters capable of altering function parameter syntax:
+
+```diff
+fixed file: lodash/lodash.js
+
+ 165    /** Used to match words composed of alphanumeric characters. */
+ 166    var reAsciiWord = /[^\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]+/g;
+ 167
++169    /**
++170     * Used to validate the `validate` option in `_.template` variable.
++171     *
++172     * Forbids characters which could potentially change the meaning of the function argument definition:
++173     * - "()," (modification of function parameters)
++174     * - "=" (default value)
++175     * - "[]{}" (destructuring of function parameters)
++176     * - "/" (beginning of a comment)
++177     * - whitespace
++178     */
++179    var reForbiddenIdentifierChars = /[()=,{}\[\]\/\s]/;
+```
+
+This rejects parentheses, braces, commas, equals signs, slashes, and whitespace. None of these characters can appear in a valid JavaScript identifier, but all of them could be used to escape the parameter context and inject code. Third, the guard was inserted into `_.template()` at lines 14882–14887 in the fixed file, immediately after the existing `if (!variable)` block:
+
+```diff
+fixed file: lodash/lodash.js
+
+ 14879    if (!variable) {
+ 14880      source = 'with (obj) {\n' + source + '\n}\n';
+ 14881    }
++14882    // Throw an error if a forbidden character was found in `variable`, to prevent
++14883    // potential command injection attacks.
++14884    else if (reForbiddenIdentifierChars.test(variable)) {
++14885      throw new Error(INVALID_TEMPL_VAR_ERROR_TEXT);
++14886    }
++14887
+ 14888    // Cleanup code by stripping empty strings.
+```
+
+If `variable` contains a forbidden character, lodash now throws immediately at line 14885 and never reaches the `Function()` call with unsafe input. Finally, a regression test was added at line 22299 in test/test.js to permanently lock in this behavior:
+
+```diff
+fixed file: test/test.js
+
+ 22298
++22299    QUnit.test('should forbid code injection through the "variable" options', function(assert) {
++22300      assert.expect(1);
++22301
++22302      assert.raises(function () {
++22303        _.template('', { 'variable': '){console.log(process.env)}; with(obj' });
++22304      });
++22305    });
++22306
+ 22307    QUnit.test('should support custom delimiters', function(assert) {
+```
+
+## Prevention
+
+The core lesson from this vulnerability is that any value influencing generated code must be treated as security-sensitive, regardless of how innocuous its name appears. The `variable` option looked like ordinary configuration, but because it reached a `Function()` call it was effectively a code injection point.
+
+The strongest prevention is to avoid runtime code generation from untrusted input entirely. Templates should be compiled at build or deploy time from trusted files, not at runtime from user-controlled options. When dynamic compilation is unavoidable, every code-shaped value must be validated with a strict allowlist rather than a blocklist. For a JavaScript identifier, the correct rule is to accept only values matching the exact identifier grammar, for example:
+
+```
+function validateTemplateVariableName(name) {
+  if (!/^[A-Za-z_$][0-9A-Za-z_$]*$/.test(name)) {
+    throw new Error('Invalid template variable name');
+  }
+  return name;
+}
+```
+
+This rejects all punctuation, whitespace, and syntax characters, accepting only values that are structurally safe to embed in a function signature. If the application does not need configurable variable names at all, the option should simply not be exposed. Hard-coding a safe value like `data` eliminates the attack surface entirely.
+
+Security testing must include negative cases that verify malformed variable names and malicious option values are rejected before compilation, not just that valid templates render correctly. Static analysis tools should trace taint from untrusted sources to dangerous sinks such as `eval`, `Function`, and runtime template compilation. Finally, teams should use software composition analysis tools such as `npm audit`, Dependabot, or Snyk to detect vulnerable dependency versions automatically. For this vulnerability, upgrading lodash to version 4.17.21 or later is the immediate remediation.
+
+## Conclusion
+
+CVE-2021-23337 demonstrates that configuration options can become code injection vectors when a library uses dynamic code generation. In vulnerable versions of lodash, the `variable` option in `_.template()` was embedded into generated JavaScript at line 14875 without validation, allowing an attacker to inject arbitrary code that was then compiled and executed by the `Function()` constructor at line 14894. The fix introduced a regular expression guard at line 14884 of the fixed file that rejects any `variable` value containing characters that could alter JavaScript syntax, closing the injection path before it reaches the compilation step. The broader lesson is that code-generation boundaries are security boundaries, and every value that influences generated code must be validated as strictly as the code itself.
+
+## References
+
+Lodash 4.17.20 Vulnerable Source Code: <https://github.com/lodash/lodash/blob/4.17.20/lodash.js#L14865-L14896>
+
+Lodash Code Commit to Fix Issue: <https://github.com/lodash/lodash/commit/3469357cff396a26c363f8c1b5a91dde28ba4b1c>
+
+CVE-2021-23337 Entry: <https://www.cve.org/CVERecord?id=CVE-2021-23337>
+
+CWE-94 Entry: <https://cwe.mitre.org/data/definitions/94.html>
+
+CAPEC-242 Entry: <https://capec.mitre.org/data/definitions/242.html>
+
+NVD Vulnerability Report: <https://nvd.nist.gov/vuln/detail/CVE-2021-23337>
+
+MDN Documentation for Function Constructor: <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/Function>
+
+
+## Contributions
+
+Originally created by Venkata Abhiram Karuturi, Jithendra Sai Pappuri, and Nikhil Akula


### PR DESCRIPTION
This PR adds a new case study for CVE-2021-23337, a CWE-94 (Code Injection) vulnerability in lodash related to the `variable` option in `_.template()`.

Group Members: Venkata Abhiram Karuturi, Jithendra Sai Pappuri, and Nikhil Akula