### PR TITLE
Add case study for CVE-2026-26830 in pdf-image

### DIFF
--- a/javascript/secure-coding-case-study-cwe-78-cve-2026-26830.md
+++ b/javascript/secure-coding-case-study-cwe-78-cve-2026-26830.md
@@ -1,0 +1,230 @@
+# OS COMMAND INJECTION IN PDF-IMAGE
+
+
+## Introduction
+
+
+[NPM](https://docs.npmjs.com/about-npm) is a library with a cast variety of software packages that allow developing in Javascript to be simpler. [Examples](https://devxhub.medium.com/30-most-popular-npm-packages-for-node-js-developers-4257a2363291) of different packages include the Express framework, Axios HTTP Framework, and the Socket.io library. However, because of the sheer number of packages that NPM offers and the fact that any developer can create a package and share it, there is bound to be insecure packages. This case study looks at a specific vulnerable package called [pdf-image](https://www.npmjs.com/package/pdf-image), which allows users to convert PDF files to images. The vulnerability discovered in this package deals with the CWE-78: Improper Neutralization of Special Elements used in an OS Command weakness. This weakness has been in the [CWE™ Top 25 Most Dangerous Software Weaknesses](https://cwe.mitre.org/top25/) for the past 7 years (ranking around 6 to 11), leading the [CVSS](https://github.com/zebbernCVE/CVE-2026-26830) of this vulnerability to be deemed critical.
+
+
+## Software
+
+
+**Name:** pdf-image NPM package version 2.0.0  
+**Language:** Javascript (Node.js)  
+**URL:** <https://www.npmjs.com/package/pdf-image>
+
+
+## Weakness
+
+
+[CWE-78: Improper Neutralization of Special Elements used in an OS Command (‘OS Command Injection’)](https://cwe.mitre.org/data/definitions/78.html)
+
+
+OS command injection deals with attackers exploiting a part of a vulnerable program that utilizes the operation system and its commands. This allows attackers to have elevated privileges and use commands that they normally wouldn’t be able to execute.
+
+
+If the program trusts attacker-supplied data when executing a command with user input, the attacker can provide input that includes a semi-colon in it, which is used to separate commands. The system will then execute the command with user input, which results in running multiple commands at once due to the semi-colon. As a result, the attacker can access unauthorized data, create a Denial of Service attack, stop the program, and more.
+
+
+## Vulnerability
+
+
+[CVE-2026-26830](https://www.cve.org/CVERecord?id=CVE-2026-26830) – Published 25 March 2026
+
+
+The pdf-image NPM package is a current example of OS command injection that needs to be mitigated immediately. [Pdf-image](https://www.npmjs.com/package/pdf-image) is used to convert PDF files into PNG images in Node.js. The vulnerability is due to the lack of input validation of the `pdfFilePath` parameter used in the `constructGetInfoCommand` and `constructConvertCommandForPage` functions (in `index.js`). The parameter is meant to be the file path to the PDF that you want converted. Then, that parameter is concatenated with the rest of the command that runs under child_process.exec(), which uses the operating system to convert the file format. However, due to the lack of input validation of the pdfFilePath parameter, an [attacker](https://www.cve.org/CVERecord?id=CVE-2026-26830) could potentially pass in input that will execute a command of their choice instead of executing the intended command with the normal PDF path.
+
+
+Looking at the [vulnerable pdf-image code](https://github.com/mooz/node-pdf-image/blob/master/index.js), the PDFImage function takes in the `pdfFilePath` parameter, and it is immediately assigned to the class variable on line 13. The parameter value comes from untrusted user input, but it is not validated and escaped before assigning it to the class variable. `constructGetInfoCommand` and `constructConvertCommandForPage` then use the unvalidated `pdfFilePath` parameter (lines 28 and 85) to build the commands. `getInfo` and `convertPage` call the command constructor functions then execute the command with the unvalidated file path on lines 44 and 170.
+```
+vulnerable file: index.js
+
+
+10 function PDFImage(pdfFilePath, options) {
+11  if (!options) options = {};
+12
+13  this.pdfFilePath = pdfFilePath;
+…
+25 constructGetInfoCommand: function () {
+26     return util.format(
+27       "pdfinfo \"%s\"",
+28       this.pdfFilePath
+29     );
+30   },
+…
+40 getInfo: function () {
+41     var self = this;
+42     var getInfoCommand = this.constructGetInfoCommand();
+43     var promise = new Promise(function (resolve, reject) {
+44       exec(getInfoCommand, function (err, stdout, stderr) {
+…
+84  constructConvertCommandForPage: function (pageNumber) {
+85     var pdfFilePath = this.pdfFilePath;
+86     var outputImagePath = this.getOutputImagePathForPage(pageNumber);
+87     var convertOptionsString = this.constructConvertOptions();
+88     return util.format(
+89       "%s %s\"%s[%d]\" \"%s\"",
+90       this.useGM ? "gm convert" : "convert",
+91       convertOptionsString ? convertOptionsString + " " : "",
+92       pdfFilePath, pageNumber, outputImagePath
+93     );
+94   },
+…
+163 convertPage: function (pageNumber) {
+164     var pdfFilePath     = this.pdfFilePath;
+165     var outputImagePath = this.getOutputImagePathForPage(pageNumber);
+166     var convertCommand  = this.constructConvertCommandForPage(pageNumber);
+167
+168     var promise = new Promise(function (resolve, reject) {
+169       function convertPageToImage() {
+170         exec(convertCommand, function (err, stdout, stderr) {
+```
+
+
+## Exploit
+
+
+To exploit this vulnerability, an attacker needs to input a shell command as a PDF file path. The following code shows a simple but effective example.
+
+
+Example: [CVE-2026-26830: OS command injection in pdf-image](https://github.com/zebbernCVE/CVE-2026-26830)
+```
+const { PDFImage } = require("pdf-image");
+
+
+const pdfImage = new PDFImage('test.pdf"; touch /tmp/pwned; echo "');
+pdfImage.getInfo();
+```
+Injecting this command will create /tmp/pwend, when the command should only be taking in “test.pdf.” This is because the inputted string is a shell command string that will get put into child_process.exec() during the execution of pdfImage.getInfo(). Since a semi-colon is Unix’s command separator and “;” was not taken out of the input string, each part of the string, “test.pdf,” “touch /tmp/pwned,” and “echo” will all get executed as separate commands. That means attackers can inject arbitrary commands that will get executed with the underlying code that PDFImage’s methods use.
+
+
+The seriousness of this vulnerability depends on how the package is used in a real application. If a developer allows a file path or PDF conversion request to be influenced by user input, an attacker may be able to execute arbitrary operating system commands with the same privileges as the Node.js process running the application. In practice, this could allow the attacker to read sensitive files, alter data, delete content, or interrupt normal service. This makes the vulnerability especially dangerous because the issue is not limited to incorrect PDF parsing, but instead, it can lead to command execution on the host system itself.
+
+
+## Fix
+
+
+According to [CVE-2026-26830: OS command injection in pdf-image](https://github.com/zebbernCVE/CVE-2026-26830), there has not been a fixed NPM release for this package yet.
+
+
+## Prevention
+
+
+While there are no released fixes yet, there are a number of recommended ways to mitigate this vulnerability.
+
+
+1. Input Validation and Sanitization
+
+
+[Command chaining](https://www.geeksforgeeks.org/linux-unix/chaining-commands-in-linux/) is an approach to run multiple commands at the same time. You can achieve this through using characters such as &, &&, ;, ||, |, !, <,>,>>, \, “”, ‘’, (), and {}. These are the characters that should be filtered out of the file path before passing it into the PDFImage constructor when creating a PDFImage object.
+- ```
+    function PDFImage(pdfFilePath, options) {
+    if (!options) options = {};
+    this.pdfFilePath = pdfFilePath;
+    ```
+    - Before directly setting this.pdfFilePath, sanitize the input by removing or rejecting dangerous metacharacters from pdfFilePath in order to provide a safe path.
+    - Even within the Node.js documentation itself, for the [child_process.exec()](https://nodejs.org/api/child_process.html#child-processexeccommand-options-callback) function, they warn, “Never pass unsanitized user input to this function. Any input containing shell metacharacters may be used to trigger arbitrary command execution.” Thus, input validation is extremely important, and the lack of it in the source code is detrimental to the security of the package.
+- While filtering shell metacharacters may block simple payloads, it should not be treated as the strongest and sole long-term fix. Blacklist-based filtering can be bypassed with obfuscation, encoding, or overlooked characters. A stronger approach is to whitelist valid input characters instead of blacklisting dangerous ones. For example, create a whitelist that only allows file paths that match a certain format (e.g., .pdf files). Or, use the whitelist that [Unix](https://www.ibm.com/docs/en/zos/2.5.0?topic=files-naming) has for allowable characters in filenames. This will reject inputs that contain unexpected and unnecessary symbols.
+- Additionally, using [path normalization](https://www.w3schools.com/nodejs/met_path_normalize.asp)) and [path resolve](https://www.geeksforgeeks.org/javascript/node-js-path-resolve-method/) can also help reduce directory traversal risks by resolving path components such as ‘..’ and ‘\\\\’. [Path normalization](https://nodejs.org/api/path.html#pathnormalizepath) replaces multiple instances of “path segment separation characters” with a single instance, such as the ones listed in the previous sentence. [Path resolve](https://nodejs.org/api/path.html#pathrelativefrom-to) utilizes the absolute path, instead of a relative path. If an absolute path can’t be created, the current directory is used, which prevents an arbitrary command to be executed.    
+    -   ```
+        let path = require('path');
+        let x = path.normalize('Users/Refsnes/../Jackson');
+        console.log(x);
+        ```
+    - In the example above, the path logged to the console is `Users\Jackson` meaning `path.normalize()` resolved the relative path and removed the unnecessary path segments.
+    - Path normalization on its own will not fully prevent directory traversal, but in combination with input validation and `path.resolve()`, it allows for the verification of the final file path.
+
+
+2. Avoid Shell Execution
+
+
+Use safer alternatives such as [execFile()](https://nodejs.org/api/child_process.html#child-processexecfilefile-args-options-callback) or [spawn()](https://nodejs.org/api/child_process.html#child-processspawncommand-args-options) with an array that breaks down the command into separate arguments instead of building one large command string for the whole command.
+- `child_process.exec()` executes commands through a shell, allowing any user input to be included in the command string and interpreted by the shell.
+- In contrast, `execFile()` and `spawn()` do not spawn a shell by default. These functions do not need a string for the command. Instead, they accept the command and its arguments as separate parameters, directly providing the arguments to the operating system and calling your executable file/command without a shell.
+- Since `execFile()`  and `spawn()` don’t rely on a shell, I/O redirection and file globbing are not supported. Thus problematic metacharacters like ‘;’ never get interpreted as a command instruction and rather get interpreted as literal input.
+- ```
+    const { execFile } = require('node:child_process');
+    const child = execFile('convert', ['input.pdf', 'output.png'], (error, stdout, stderr) => {
+        if (error) {
+        throw error;
+        }
+        console.log(stdout);
+    });
+    ```
+    - By building the command this way, the PDF path would be handled strictly as data, not as part of a shell command. This design change addresses the root cause of the vulnerability more effectively than only attempting to strip suspicious characters from the input.
+
+
+3. Principle of Least Privilege
+
+
+Another thing to consider is limiting the impact of a successful exploitation. By following the [principle of least privilege](https://www.crowdstrike.com/en-us/cybersecurity-101/identity-protection/principle-of-least-privilege-polp/), you can ensure that users are given only the permissions necessary to complete their task. By limiting system permissions, even if an attacker executes a command, you can do a few things to make sure that the attacker cannot access sensitive information about the system.
+- In the case of pdf-image’s vulnerability, restricting the privileges of Node.js and not running it as root can help reduce the impact. This would give the attacker limited access to system resources. Additionally, running the application that uses this package in a restricted and contained environment, such as a Docker container, as a non-root user will also restrict the file system seen by the user and only gives them the directories necessary to convert the pdf file.
+
+
+## Conclusion
+
+
+This vulnerability demonstrates just how important input validation is in all code. It is very easy to glance at pdf-image’s methods like getInfo() and not realize that it actually utilizes the operating system and its commands. Adding additional checks to strip input strings of special characters when they are not needed and using argument-safe process execution functions will eliminate the weakness CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection'). If this weakness is resolved, attackers will no longer be able to execute unauthorized operating system commands.
+
+
+## References
+
+
+GitHub Repository for CVE-2026-26830: <https://github.com/zebbernCVE/CVE-2026-26830>
+
+
+NPM Package: pdf-image: <https://www.npmjs.com/package/pdf-image>
+
+
+CWE-78 Entry: <https://cwe.mitre.org/data/definitions/78.html>
+
+
+CVE-2026-26830 Record: <https://www.cve.org/CVERecord?id=CVE-2026-26830>
+
+
+MITRE CWE Top 25 Most Dangerous Software Weaknesses: <https://cwe.mitre.org/top25/>
+
+
+DevXHub. "30 Most Popular NPM Packages for Node.js Developers." <https://devxhub.medium.com/30-most-popular-npm-packages-for-node-js-developers-4257a2363291>
+
+
+NPM Documentation: <https://docs.npmjs.com/about-npm>
+
+
+GitHub Repository: node-pdf-image. <https://github.com/mooz/node-pdf-image>
+
+
+Node.js Documentation. “child_process.exec().” <https://nodejs.org/api/child_process.html#child-processexeccommand-options-callback>
+
+
+Node.js Documentation. “child_process.spawn().” <https://nodejs.org/api/child_process.html#child-processspawncommand-args-options>
+
+
+GeeksforGeeks. “Chaining Commands in Linux.” <https://www.geeksforgeeks.org/linux-unix/chaining-commands-in-linux/>
+
+
+W3Schools. “Node.js path.normalize() Method.” <https://www.w3schools.com/nodejs/met_path_normalize.asp>
+
+
+GeeksforGeeks. “Node path.resolve() Method.” <https://www.geeksforgeeks.org/javascript/node-js-path-resolve-method/>
+
+
+CrowdStrike. “Intro to The Principle of Least Privilege (POLP).” <https://www.crowdstrike.com/en-us/cybersecurity-101/identity-protection/principle-of-least-privilege-polp/>
+
+
+IBM. "Naming files." <https://www.ibm.com/docs/en/zos/2.5.0?topic=files-naming>
+
+
+Node.js Documentation. "path.relative(from, to)" <https://nodejs.org/api/path.html#pathrelativefrom-to>
+
+
+Node.js Documentation. "path.normalize(path)" <https://nodejs.org/api/path.html#pathnormalizepath>
+## Contributions
+Originally created by Cassandra Nguyen, Thi Ley, and Loc Nguyen
+
+
+
+
+
+


### PR DESCRIPTION
This pull request adds a secure coding case study for CVE-2026-26830 in the pdf-image npm package.

Summary:
- Software: pdf-image (JavaScript / Node.js)
- Vulnerability: CVE-2026-26830
- Weakness discussed: CWE-78: OS Command Injection
- Includes sections on the vulnerability, exploit, fix, prevention, and references

Related issue: #68 
Contributors:
- Thi Ley
- Cassandra Nguyen
- Loc Nguyen