### PR TITLE
Add case study for CVE-2024-36039 (SQL Injection in PyMySQL)

### DIFF
--- a/python/secure-coding-case-study-cwe-89-cve-2024-36039.md
+++ b/python/secure-coding-case-study-cwe-89-cve-2024-36039.md
@@ -1,0 +1,140 @@
+# SQL INJECTION IN PYMYSQL
+
+## Introduction
+
+Databases are the backbone of most modern applications, and the libraries that connect applications to those databases are trusted to safely carry user input into SQL queries. Unfortunately, when those libraries make assumptions about which parts of the input are "safe," attackers can slip malicious SQL past the guardrails. The underlying source code weakness that makes such attacks possible is consistently one of the CWE Top 25 Most Dangerous Software Weaknesses, ranked third in the 2024 list. In 2024 such a vulnerability was disclosed in PyMySQL, a pure-Python MySQL client library used by thousands of projects and widely relied on for applications that do not use a full object-relational mapper. PyMySQL exposes escape helpers that applications call to sanitize values before they are interpolated into SQL statements, but one of those helpers silently trusted a portion of its input that could come directly from untrusted JSON. This case study will look at that vulnerability, the mistake made by the developers, what it enabled an adversary to accomplish, and how the code was eventually corrected.
+
+## Software
+
+**Name:** PyMySQL  
+**Language:** Python  
+**URL:** <https://github.com/PyMySQL/PyMySQL>
+
+## Weakness
+
+[CWE-89: Improper Neutralization of Special Elements Used in an SQL Command](https://cwe.mitre.org/data/definitions/89.html)
+
+The weakness exists when software constructs all or part of an SQL command using externally influenced input that has been obtained from an upstream component, but the software does not neutralize (e.g., canonicalize, encode, escape, quote, validate) or incorrectly neutralizes special elements that could modify the intent of the SQL command. The result is that what the developer intended as a data value is reinterpreted by the database as part of the SQL syntax itself, allowing an adversary to change the meaning of the query.
+
+A classic example of this type of weakness is when string concatenation is used to build an SQL command with untrusted input from sources like network requests, file data, or parsed JSON documents. The example code snippet below shows this weakness in generic form:
+
+```
+user_input = request.get_json()["name"]
+cursor.execute("SELECT * FROM users WHERE name = '" + user_input + "'")
+```
+
+If the attacker supplies a value of `' OR '1'='1`, the resulting SQL becomes `SELECT * FROM users WHERE name = '' OR '1'='1'`, which returns every row in the table. Variants of this weakness are particularly dangerous when a library provides escaping helpers that appear to sanitize input but in fact leave some portion of the input unescaped. Developers who see an `escape()` call in their code naturally assume the output is safe, and that false sense of security tends to remove the pressure to use safer mechanisms like parameterized queries.
+
+## Vulnerability
+
+[CVE-2024-36039](https://www.cve.org/CVERecord?id=CVE-2024-36039) – Published 21 May 2024
+
+PyMySQL is a pure-Python implementation of the MySQL client protocol. Applications use it to open connections, execute queries, and read results, and many web frameworks and scripts that need direct SQL access depend on it. Among its public APIs is `Connection.escape()`, which applications can call to escape a value before building an SQL string. Internally this method dispatches to a family of `escape_*` functions based on the type of the argument. When the argument is a Python dictionary, it dispatches to `escape_dict()` in `pymysql/converters.py`.
+
+Looking at the vulnerable source code in `pymysql/converters.py`, lines 29–33 define `escape_dict`. The function creates a new dictionary `n`, iterates over the items of the incoming dictionary `val`, and for each key-value pair calls `escape_item(v, charset, mapping)` on the value before storing it back in `n` under the original key `k`. The return value is a dictionary whose values are escaped SQL literals and whose keys are whatever the caller passed in, completely unmodified. This is the source-to-sink flow: the dictionary values travel through `escape_item` and reach the database as properly quoted literals, but the dictionary keys travel directly from the caller to the returned structure and onward into any SQL string that is built from the result. The implicit assumption of the code is that dictionary keys are written by the developer and therefore trusted. That assumption holds when dictionaries are constructed in Python source, but it breaks the moment a dictionary is produced by `json.loads()` on untrusted input, because in JSON the object property names are attacker-controlled strings.
+
+```
+vulnerable file: pymysql/converters.py
+
+ 27	def escape_item(val, charset, mapping=None):
+ ...
+ 29	def escape_dict(val, charset, mapping=None):
+ 30	    n = {}
+ 31	    for k, v in val.items():
+ 32	        quoted = escape_item(v, charset, mapping)
+ 33	        n[k] = quoted
+ 34	    return n
+```
+
+On line 31 the loop unpacks the key into `k` without ever routing it through `escape_item`, and on line 33 that raw key is used as the dictionary index in the returned structure. Any caller that builds an SQL fragment from the keys of the returned dictionary — for example, constructing an `INSERT` statement by joining the keys to form the column list, or building a `WHERE` clause by pairing keys with their escaped values — will inject the attacker's key string directly into the query. The vulnerability is not that `escape_dict` corrupts the values; it is that the function's name and position in the API suggest it has sanitized the whole dictionary when in reality it has only sanitized half of it.
+
+## Exploit
+
+[CAPEC-66: SQL Injection](https://capec.mitre.org/data/definitions/66.html)
+
+To exploit this vulnerability an adversary needs to reach an application that accepts JSON input from an untrusted source, parses it into a Python dictionary, passes that dictionary through `Connection.escape()` or directly through `escape_dict()`, and then uses the resulting keys when constructing an SQL statement. Web APIs that accept JSON request bodies and translate those bodies into database writes are the most natural targets. Consider an application that accepts a JSON document describing a new record and inserts it by pulling column names from the dictionary keys:
+
+```
+body = json.loads(request.body)            # attacker-controlled JSON
+escaped = connection.escape(body)          # dispatches to escape_dict
+columns = ", ".join(escaped.keys())
+values  = ", ".join(escaped.values())
+cursor.execute(f"INSERT INTO items ({columns}) VALUES ({values})")
+```
+
+An attacker who controls the request body can send a JSON document whose object property name contains SQL syntax. For example:
+
+```
+{"name) VALUES ('pwned'); DROP TABLE items; -- ": "ignored"}
+```
+
+When this document is parsed the resulting Python dictionary has a single key that includes a closing parenthesis, a complete `INSERT`, a `DROP TABLE` statement, and an SQL comment to swallow the rest of the original query. Because `escape_dict` never touches the key, the application concatenates that key verbatim into the final SQL string. The query that reaches the server bears little resemblance to the one the developer wrote, and the attacker has achieved arbitrary SQL execution on the database. The impact depends on the privileges of the database account the application uses, but because injection happens at the statement level the attacker can read any data the account can read, modify or delete rows, and in some configurations issue administrative commands.
+
+Authentication is not inherently required to trigger this vulnerability; any endpoint that forwards parsed JSON into the dictionary escape path is reachable. The vulnerability was scored CVSS 9.8 (Critical) by NIST precisely because the attack vector is network-based, the complexity is low, no privileges are required, and the confidentiality, integrity, and availability impacts are all high.
+
+## Fix
+
+The upstream fix in commit `521e400` takes a deliberately blunt approach: instead of trying to teach `escape_dict` how to safely quote dictionary keys for every possible SQL context, the maintainers removed the dangerous behavior entirely. The function no longer returns a partially-escaped dictionary. It raises `TypeError` and refuses to process the input at all. Callers that previously relied on passing dictionaries through `escape()` are forced to restructure their code, typically by switching to parameterized queries, which is the correct long-term fix anyway.
+
+```diff
+fixed file: pymysql/converters.py
+
+ 27	def escape_item(val, charset, mapping=None):
+ ...
+ 29	def escape_dict(val, charset, mapping=None):
+-30	    n = {}
+-31	    for k, v in val.items():
+-32	        quoted = escape_item(v, charset, mapping)
+-33	        n[k] = quoted
+-34	    return n
++30	    raise TypeError("dict can not be used as parameter")
+```
+
+Lines 30–34 of the vulnerable file are deleted and replaced by a single `raise` on the new line 30. The accompanying test file `pymysql/tests/test_connection.py` was updated in the same commit: the previous test `test_escape_dict_value`, which asserted that `con.escape({"foo": Foo()}, mapping)` returned an escaped dictionary, was renamed to `test_escape_dict_raise_typeerror` and rewritten to assert that the call now raises `TypeError`. Changing the test in lockstep with the code is an important part of the fix, because it turns the new behavior into a contract that cannot silently regress. The library's CHANGELOG for v1.1.1 documents the change explicitly, noting that dict parameters to `Cursor.execute()` never produced valid SQL and might cause SQL injection, and that they are now prohibited.
+
+The fix does not attempt to repair the underlying design mismatch between "trusted dictionary keys written by developers" and "untrusted dictionary keys produced by JSON parsers." It simply removes the code path that conflated the two. This is a good example of choosing deletion over complication when a feature cannot be made safe without changing how callers use it.
+
+## Prevention
+
+The most important prevention for this class of weakness is to build SQL with parameterized queries and to never construct SQL by concatenating or interpolating values, regardless of whether those values have been passed through an escape function. Parameterization sends the SQL statement and its data to the database through separate channels, so the database parses the statement once and then binds the data as opaque values that cannot be reinterpreted as syntax. In PyMySQL this means calling `cursor.execute("INSERT INTO items (name, price) VALUES (%s, %s)", (name, price))` with a hard-coded column list and a tuple of values, rather than deriving column names from untrusted input at all. If the set of columns genuinely needs to vary at runtime, the column names should be validated against a fixed allowlist defined in the application code before they are ever inserted into an SQL string. An allowlist check is cheap to write, easy to audit, and makes it impossible for an attacker-controlled string to reach the query as identifier syntax. A reviewer examining `escape_dict`'s original implementation would have asked, "what happens when the keys come from JSON?" and an allowlist would have been the obvious answer; its absence is what allowed the vulnerability to ship.
+
+Static analysis tools that perform taint tracking from untrusted sources (network inputs, `json.loads`, request bodies) to SQL sinks (`cursor.execute`, string formatting that produces SQL) are effective at catching this pattern before code is released. Bandit, Semgrep with the `python.flask.security` or `python.lang.security` rule packs, and commercial SAST products all flag SQL built from formatted strings when any component traces back to an untrusted source. In the PyMySQL case, a taint-aware analyzer examining a typical downstream application would have followed the flow `json.loads(request.body)` → `connection.escape(...)` → `", ".join(...keys())` → `cursor.execute(f"... {columns} ...")` and reported that an untrusted value reached a SQL sink through a path that only escaped some of it. The lesson for library authors is that any function named `escape_*` is implicitly treated by SAST tools and by human reviewers as a sanitizer; if it only sanitizes part of its input, that partial coverage is itself a defect and the function should either fully sanitize or refuse the input, which is exactly the direction the PyMySQL fix went.
+
+A third layer of prevention is property-based and negative testing of sanitizer functions. Positive tests that confirm `escape_dict({"name": "Alice"})` returns the expected structure do not exercise the case where a key contains SQL metacharacters. A property-based test framework like Hypothesis can be configured to generate dictionary inputs whose keys are drawn from a character set that includes quotes, semicolons, parentheses, and comment markers, then assert that the function either rejects the input or produces output that round-trips safely through the database. Had such tests existed for `escape_dict`, they would have either flagged that the function silently accepted dangerous keys or forced the maintainers to decide explicitly what keys meant, and the original design mismatch would have been surfaced before a CVE was needed. More generally, any function that claims to sanitize should have negative tests built around the threat model it is defending against, not just positive tests confirming it works on benign input.
+
+Finally, at the application layer, do not pass parsed JSON structures directly into database APIs. The boundary between "data from the network" and "data used to build a query" should be an explicit translation step in application code: receive JSON, extract the specific fields you expect by name into typed variables, validate each one, and then pass those validated values as parameters to a hard-coded SQL statement. This pattern is more verbose than the shortcut of looping over a dictionary, but it removes the entire class of problems that CVE-2024-36039 represents, and it keeps the application safe even when a transitive dependency has a subtle escaping bug.
+
+## Conclusion
+
+The removal of the unsafe dictionary-escaping path from PyMySQL eliminates the weakness CWE-89: Improper Neutralization of Special Elements Used in an SQL Command in the specific form that reached production. With `escape_dict` now raising `TypeError`, applications that previously relied on the partially-escaped dictionary behavior fail loudly at the point of misuse rather than silently forwarding attacker-controlled identifiers into SQL queries, and CVE-2024-36039 is no longer reachable through the library's API. The broader takeaway is that any function that sanitizes only part of its input is a liability: developers and static analyzers treat sanitizer names as promises, and a promise that holds for values but not for keys is a promise that will eventually be broken by an attacker-controlled JSON document.
+
+## References
+
+PyMySQL Project Page: <https://github.com/PyMySQL/PyMySQL>
+
+CVE-2024-36039 Entry: <https://www.cve.org/CVERecord?id=CVE-2024-36039>
+
+CWE-89 Entry: <https://cwe.mitre.org/data/definitions/89.html>
+
+CAPEC-66 Entry: <https://capec.mitre.org/data/definitions/66.html>
+
+NVD Vulnerability Report: <https://nvd.nist.gov/vuln/detail/CVE-2024-36039>
+
+GitHub Security Advisory GHSA-v9hf-5j83-6xpp: <https://github.com/advisories/GHSA-v9hf-5j83-6xpp>
+
+PyMySQL Code Commit to Fix Issue: <https://github.com/PyMySQL/PyMySQL/commit/521e40050cb386a499f68f483fefd144c493053c>
+
+PyMySQL v1.1.1 Release Notes: <https://github.com/PyMySQL/PyMySQL/releases/tag/v1.1.1>
+
+PyMySQL Documentation - Cursor.execute Parameterization: <https://pymysql.readthedocs.io/en/latest/modules/cursors.html>
+
+OWASP SQL Injection Prevention Cheat Sheet: <https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html>
+
+## Contributions
+
+Originally created by Gondi Tarun Datta - George Mason University  
+Originally created by Goduguluri Varshitha - George Mason University  
+Reviewed by Drew Buttner - The MITRE Corporation  
+
+(C) 2026 The Authors. All rights reserved.  
+This work is openly licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)


### PR DESCRIPTION
This PR adds a secure coding case study for CVE-2024-36039, a SQL injection vulnerability in PyMySQL's `escape_dict` function caused by failure to sanitize dictionary keys when the dictionary originates from untrusted JSON.

   Closes #70.

   Co-authored-by: Goduguluri Varshitha