### PR TITLE
Add case study: HTTP Request Smuggling in Kestrel (CVE-2025-55315)

### DIFF
--- a/secure-coding-case-study-cwe-444-cve-2025-55315.md
+++ b/secure-coding-case-study-cwe-444-cve-2025-55315.md
@@ -1,0 +1,168 @@
+# HTTP REQUEST SMUGGLING IN KESTREL
+
+## Introduction
+
+HTTP request smuggling vulnerabilities occur when there is a mismatch in how two systems interpret the boundaries of an HTTP request. CVE-2025-55315 is a severe example of this vulnerability in Kestrel, the default HTTP server of ASP.NET Core, Microsoft's popular open-source web development framework. The exploit is a result of a particular error in Kestrel's chunked request parser. While parsing chunk extensions - optional fields in chunked HTTP requests - Kestrel only looked for carriage return `\r` as a possible line terminator, but not bare line feed `\n`. According to the HTTP/1.1 specification (RFC 9112), only `\r\n` is legal. This allowed Kestrel to parse lines ending in bare `\n`, and introduce a parsing differential with upstream proxies that rejected these malformed lines. Exploiting this discrepancy, an attacker could smuggle an additional request through the proxy to the server. Disclosed on October 14, 2025, this vulnerability scored 9.9 out of 10 on the CVSS scale - the highest score Microsoft has ever given to a .NET vulnerability. It affects all versions of ASP.NET Core from .NET Core 3.0 through .NET 9.0.9 and .NET 8.0.20. This could lead to authentication bypass, server-side request forgery, credential theft, and injections, among other attacks. This case study will look at that vulnerability, the mistake made by the developers, what it enabled an adversary to accomplish, and how the code was eventually corrected.
+
+## Software
+
+**Name:** ASP.NET Core (Kestrel HTTP Server)  
+**Language:** C#  
+**URL:** <https://github.com/dotnet/aspnetcore>
+
+## Weakness
+
+[CWE-444: Inconsistent Interpretation of HTTP Requests](https://cwe.mitre.org/data/definitions/444.html)
+
+Inconsistent Interpretation of HTTP Requests (CWE-444) happens when two systems that receive the same HTTP request use different criteria to identify where one request stops and another starts. This presents an opportunity for an attacker to send a request which one system interprets as a single request and the other interprets as two separate requests.
+
+This weakness commonly arises in systems where a proxy server sits in front of a backend server. If the proxy and the backend apply different parsing rules to the same HTTP request, an attacker can craft a request that exploits the difference. The proxy sees one complete request and forwards it, while the backend sees two requests - the second of which was never seen or validated by the proxy. The following generic example illustrates how conflicting interpretations of a two-byte line terminator can cause this problem. If a parser searches only for `\r` instead of the full `\r\n` sequence required by the specification, a bare `\n` in the input will be invisible to that parser, while another system treating `\n` as a valid terminator will interpret the message boundary differently.
+
+## Vulnerability
+
+[CVE-2025-55315](https://www.cve.org/CVERecord?id=CVE-2025-55315) — Published October 14, 2025
+
+To understand the vulnerability, it is necessary to first understand chunked transfer encoding. If an HTTP client does not know the total length of the request body upfront, it can transmit the body in pieces using `Transfer-Encoding: chunked`. Each piece, called a chunk, begins with a header containing the chunk size in hexadecimal followed by a required `\r\n`, then the chunk data, followed by another `\r\n`. The request body is terminated with a zero-length chunk `0\r\n\r\n`.
+
+HTTP/1.1 also supports optional chunk extensions, which allow attaching metadata to individual chunks. A chunk extension appears after the chunk size, separated by a semicolon - for instance `9;foo=bar\r\n`. In practice, no real-world client sends chunk extensions and no server does anything meaningful with them. Kestrel's approach was simply to ignore them by reading bytes until a line ending was detected.
+
+The coding mistake lives in the `ParseExtension()` method in `Http1ChunkedEncodingMessageBody.cs`. The vulnerable code searched for the end of a chunk extension like this:
+
+```
+vulnerable file: src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
+
+   private const byte ByteCR = (byte)'\r';
+   private const byte ByteLF = (byte)'\n';
+
+   ...
+
+   SequencePosition? extensionCursorPosition = buffer.PositionOf(ByteCR);
+```
+
+Here is the vulnerability's source. The parser only searched for `\r` (carriage return). When it found `\r`, it checked whether the next byte was `\n`. If yes, it treated the sequence as a valid `\r\n` line ending and moved on. If not, it kept searching. The critical problem is what happened when the input contained a bare `\n` with no preceding `\r` - the parser never found it. It did not reject the request. It did not throw an error. It simply continued waiting for more data, effectively stalling.
+
+This behavior directly violates Section 7.1 of RFC 9112, which is explicit that chunk headers must be terminated by `\r\n`. Bare `\n` is not a valid terminator and must be rejected. Kestrel did not reject it - it failed to detect it entirely. This created an exploitable parsing differential with upstream proxies that did treat bare `\n` as a valid line terminator, causing the proxy and Kestrel to disagree on where the request ended.
+
+## Exploit
+
+[CAPEC-33: HTTP Request Smuggling](https://capec.mitre.org/data/definitions/33.html)
+
+To exploit this vulnerability, an attacker crafts a chunked HTTP request containing a malformed chunk extension that uses a bare `\n` instead of `\r\n` as the line terminator. The following example illustrates the attack:
+
+```
+POST /example HTTP/1.1
+Host: target.com
+Transfer-Encoding: chunked
+
+2;\n
+xx\r\n
+47\r\n
+GET /admin HTTP/1.1
+Host: target.com
+
+\r\n
+0\r\n
+\r\n
+```
+
+When this request reaches Kestrel after passing through the proxy, the two systems interpret it differently. The proxy recognises `\n` as a valid line ending, treats the entire payload as a single complete chunked request, and forwards it to Kestrel unchanged. The vulnerable Kestrel parser, however, only searches for `\r` in the chunk extension. It finds none after the `;` in `2;\n`. Rather than rejecting the request, Kestrel stalls - waiting for more data. When the remaining bytes eventually arrive, Kestrel treats them as a brand new separate request. The smuggled `GET /admin` request is now processed by Kestrel as an independent request, bypassing all checks performed by the proxy.
+
+The consequences of this attack depend on the specific application, but can include bypassing proxy-level authentication or authorization, gaining access to internal endpoints that the proxy was configured to block, injecting malicious headers such as `X-SSL-CLIENT-CN` to impersonate another user, stealing session tokens or credentials from other users' requests, server-side request forgery, and cache poisoning. No authentication is required to trigger this vulnerability. It only affects HTTP/1.0 and HTTP/1.1 - HTTP/2 and HTTP/3 do not support chunked transfer encoding and are therefore not affected.
+
+## Fix
+
+The fix was committed on October 14, 2025 in PR #64037 by BrennanConroy and wtgodbe, modifying `Http1ChunkedEncodingMessageBody.cs`. The change replaced a search for only `\r` with a search for both `\r` and `\n`, and added strict rejection logic for any line ending that is not exactly `\r\n`.
+
+The old vulnerable code searched only for carriage return:
+
+```diff
+vulnerable file: src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
+
+-  SequencePosition? extensionCursorPosition = buffer.PositionOf(ByteCR);
+```
+
+The new fixed code searches for both characters:
+
+```diff
+fixed file: src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
+
++  extensionCursorPosition = buffer.PositionOfAny(ByteCR, ByteLF);
+```
+
+After finding either character, the new logic checks strictly whether the sequence is exactly `\r\n`. If it is, parsing continues normally. If it is anything else - a bare `\n`, a bare `\r`, or `\r` followed by a non-`\n` character - Kestrel now immediately throws a `KestrelBadHttpRequestException`:
+
+```diff
+fixed file: src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
+
++  if (suffixSpan[0] == ByteCR && suffixSpan[1] == ByteLF)
++  {
++      // Valid \r\n — continue normally
++      _mode = _inputLength > 0 ? Mode.Data : Mode.Trailer;
++  }
++  else
++  {
++      // Anything else — bare \n, bare \r, or \r followed by non-\n
++      KestrelBadHttpRequestException.Throw(RequestRejectionReason.BadChunkExtension);
++  }
+```
+
+The fix also made three additional changes across the codebase. A new rejection reason `BadChunkExtension` was added to `RequestRejectionReason.cs`. A new error message `"Bad chunk extension"` was added to `CoreStrings.resx`. Kestrel now returns HTTP 400 Bad Request immediately when it encounters a malformed chunk extension, instead of stalling indefinitely.
+
+New regression tests were added in `ChunkedRequestTests.cs` that explicitly verify both `2;\r` and `2;\n` in chunk extensions return HTTP 400:
+
+```
+src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedRequestTests.cs
+
+   [InlineData("2;\rxx\r\nxy\r\n0")] // \r in chunk extensions
+   [InlineData("2;\nxx\r\nxy\r\n0")] // \n in chunk extensions
+   public async Task RejectsInvalidChunkExtensions(string invalidChunkLine)
+```
+
+An opt-out switch `Microsoft.AspNetCore.Server.Kestrel.EnableInsecureChunkedRequestParsing` was also introduced, which restores the old vulnerable parsing behavior. This switch should never be enabled in production.
+
+## Prevention
+
+The vulnerability CVE-2025-55315 was a result of an overly permissive parser. There are a number of software development practices that would have helped avoid this vulnerability or mitigate its effects. The key principle is that parsers need to be fail closed. A parser must reject input that is not compliant with the specification and return an error. It should not ignore it, try and correct it, or wait for further information. Section 7.1 of RFC 9112 bans the use of `\n` in chunk extensions. The parser should have thrown a `BadChunkExtension` error at the first sign of `\n` without an `\r`. The patch does this - but it should have been the design in the first place. The principle is this: if it is not allowed, do not parse it.
+
+A corollary rule is to not search for only part of a required delimiter. The vulnerable code checked only for `\r`, when the delimiter was the two-character sequence `\r\n`. This was a typical parsing error - performing a partial search for a two-character sequence. When parsing a two-character delimiter, the parser should search for both. It is necessary to use `PositionOfAny(ByteCR, ByteLF)` to find any possible line ending, and then insist on the entire `\r\n` before accepting it, as in the fix.
+
+Negative regression tests are crucial for any parser handling security-sensitive protocols. The existing tests did not include a test that sends a bare `\n` in a chunk extension and expects Kestrel to respond with an HTTP 400 error. This would have prevented the vulnerability from being released. For every valid input that a parser accepts, the test suite must have at least one test of the nearest invalid alternative. In the case of chunk extensions, the minimum negative tests must show that a chunk extension ending with bare `\n` returns 400, a chunk extension ending with bare `\r` returns 400, and a chunk extension ending with `\r` followed by a non-`\n` character returns 400. These are the tests that were introduced by the fix. They should have been there from the beginning.
+
+HTTP parser code is always security-sensitive, even if the changes look innocuous. The parser code is at the trust boundary between the client and the application. All changes to the parsing rules, even cosmetic differences in how ignored fields are skipped, must be treated as a security-critical change. The chunk extension parser was invisible: no client sent chunk extensions, no server responded to chunk extensions, and nobody cared how chunk extensions were parsed. This invisibility is how the vulnerability was able to persist for so long.
+
+Unit testing a server in isolation is not enough to detect request smuggling vulnerabilities. This type of vulnerability only occurs when a proxy and a server handle requests differently. The proxy and server must be tested together to ensure that they agree on the boundaries of requests. Research tools like PortSwigger's HTTP request smuggling tools are designed to discover such parsing differences and should be included in any security testing of an HTTP server.
+
+Finally, when specifications are revised, the parser should be reviewed to ensure it complies. RFC 9112 supersedes RFC 7230 and introduces new requirements for chunk extensions. An audit of Kestrel's chunk extension parser based on RFC 9112 Section 7.1 would have quickly revealed that bare `\n` was not being rejected. Keeping implementations up-to-date with the latest version of the specification is a straightforward practice that would have prevented this vulnerability from becoming a production issue.
+
+## Conclusion
+
+The inclusion of strict `\r\n` checks in Kestrel's chunk extension parser removed the parsing discrepancy between Kestrel and upstream proxies that allowed CVE-2025-55315 to be exploited. The change - detecting both `\r` and `\n`, and rejecting any line ending that is not exactly `\r\n` - resolves CWE-444 (Inconsistent Interpretation of HTTP Requests) by eliminating the ambiguity that made request smuggling possible.
+
+The broader lesson from this vulnerability is that leniency in parsing security-critical protocols is dangerous. Chunk extensions were innocuous and invisible - no client sent them, no server used them - and so the code that processed them received no security scrutiny for years. That invisibility was the vulnerability. Any code that sits at the boundary between untrusted input and application logic must be held to the strictest possible standard, regardless of how unimportant it appears. Parsers must fail closed. If the protocol specification does not permit something, the implementation must not accept it - not silently, not by normalizing it, and not by waiting for more data. Had this principle been consistently applied, this vulnerability would never have been released.
+
+## References
+
+ASP.NET Core GitHub Repository: <https://github.com/dotnet/aspnetcore>
+
+Microsoft Security Advisory CVE-2025-55315: <https://github.com/dotnet/aspnetcore/security/advisories/GHSA-5rrx-jjjq-q2r5>
+
+CVE-2025-55315 Entry: <https://www.cve.org/CVERecord?id=CVE-2025-55315>
+
+CWE-444 Entry: <https://cwe.mitre.org/data/definitions/444.html>
+
+CAPEC-33 Entry: <https://capec.mitre.org/data/definitions/33.html>
+
+RFC 9112 Section 7.1 - Chunked Transfer Coding: <https://www.rfc-editor.org/rfc/rfc9112#section-7.1>
+
+Fix PR #64037 - Fix chunked request parsing: <https://github.com/dotnet/aspnetcore/pull/64037>
+
+Jeppe Bonde Weikop, "Funky chunks: abusing ambiguous chunk line terminators for request smuggling" (June 18, 2025): <https://w4ke.info/2025/06/18/funky-chunks.html>
+
+Andrew Lock, "Understanding the worst .NET vulnerability ever: request smuggling and CVE-2025-55315": <https://andrewlock.net/understanding-the-worst-dotnet-vulnerability-request-smuggling-and-cve-2025-55315/>
+
+Praetorian, "How I Found the Worst ASP.NET Vulnerability - A $10K Bug (CVE-2025-55315)": <https://www.praetorian.com/blog/how-i-found-the-worst-asp-net-vulnerability-a-10k-bug-cve-2025-55315/>
+
+## Contributions
+
+Yukta Batra and Sehaj Gill  
+SWE-681, George Mason University


### PR DESCRIPTION
This PR adds a secure coding case study for CVE-2025-55315, 
HTTP Request Smuggling in ASP.NET Core Kestrel via malformed 
chunk extension parsing. Proposed in issue #72.

Contributors: Yukta Batra and Sehaj Gill
Course: SWE-681, George Mason University