### PR TITLE
Add case study: CVE-2022-26134 (OGNL Injection in Atlassian Confluence)

### DIFF
--- a/c/secure-coding-case-study-cwe-917-cve-2022-26134.md
+++ b/c/secure-coding-case-study-cwe-917-cve-2022-26134.md
@@ -1,0 +1,190 @@
+# OGNL INJECTION IN ATLASSIAN CONFLUENCE
+
+## Introduction
+
+Java-based web applications frequently use Expression Languages (EL) to dynamically resolve values and bind data to views. When user-supplied input reaches an expression language interpreter without proper validation, an attacker can inject their own expressions and have them evaluated on the server.
+
+This class of vulnerability is called "Expression Language Injection" also referred to as OGNL Injection when it involves Object-Graph Navigation Language and is catalogued as CWE-917 in the Common Weakness Enumeration.
+
+Atlassian Confluence is a widely-deployed enterprise team collaboration and documentation platform. This case study examines CVE-2022-26134, a critical pre-authentication remote code execution (RCE) vulnerability in Confluence Server and Data Center. An attacker could embed an OGNL expression directly in a crafted HTTP request URI and have it executed by the server with no authentication required.
+
+## Software
+
+**Name:** Atlassian Confluence Server and Data Center  
+**Language:** Java  
+**URL:** <https://www.atlassian.com/software/confluence>
+
+## Weakness
+
+[CWE-917: Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')](https://cwe.mitre.org/data/definitions/917.html)
+
+The fundamental weakness here is that user-controlled data  specifically the HTTP request URI  was passed directly into an OGNL expression evaluator without any sanitization or validation. OGNL (Object-Graph Navigation Language) is an open-source expression language for Java that allows callers to get and set object properties, invoke methods, and execute arbitrary Java code via reflection.
+
+When an application evaluates attacker-supplied strings as OGNL expressions, the attacker gains the ability to invoke Java runtime methods  including `Runtime.exec()` to run arbitrary operating system commands on the server.
+
+The underlying cause is that the application conflates data with code. Developers may use expression evaluation as a routing convenience without anticipating that an unauthenticated caller fully controls the input string. Without an allow-list or expression sandbox, there is nothing to prevent the injected expression from accessing dangerous Java classes.
+
+## Vulnerability
+
+[CVE-2022-26134](https://www.cve.org/CVERecord?id=CVE-2022-26134) – Published 02 June 2022
+
+Atlassian Confluence Server and Data Center use the **WebWork 2** MVC framework (a fork of Apache XWork/Struts 2) for routing HTTP requests to actions. When a request arrives, the framework maps the URI to a configured action via `xwork.xml`.
+
+One component in this pipeline is `ActionChainResult`, which handles chaining from one action to another. Its `execute()` method retrieves the `namespace` for the next action and calls `TextParseUtil.translateVariables()` on it to resolve any embedded `${...}` expressions.
+
+*The following code snippets are simplified excerpts based on public technical analyses of the vulnerable and patched XWork components, illustrating the data flow and security flaw.*
+
+```
+vulnerable file: xwork-1.0.3.6.jar
+               → com/opensymphony/xwork/ActionChainResult.java
+
+ public void execute(final ActionInvocation invocation) throws Exception {
+     if (this.namespace == null) {
+         this.namespace = invocation.getProxy().getNamespace();
+     }
+     final OgnlValueStack stack = ActionContext.getContext().getValueStack();
+
+-    final String finalNamespace = TextParseUtil.translateVariables(this.namespace, stack);
+-    final String finalActionName = TextParseUtil.translateVariables(this.actionName, stack);
+
+     if (this.isInChainHistory(finalNamespace, finalActionName)) {
+         throw new XworkException("infinite recursion detected");
+     }
+     ...
+ }
+```
+
+The two lines marked `-` are where the vulnerability lives. The value of `this.namespace` comes directly from the incoming HTTP request URI. `TextParseUtil.translateVariables()` scans that string for `${...}` tokens and, for each one found, calls `OgnlValueStack.findValue()` to evaluate the enclosed content as an OGNL expression.
+
+Because `findValue()` evaluates arbitrary OGNL against the full XWork value stack which exposes Java reflection any expression embedded in the URI gets executed with the privileges of the Confluence server process.
+
+What makes this especially dangerous is that the vulnerable code path runs before any authentication checks. It is reachable via any HTTP method GET, POST, PUT, or even an invalid verb. Any Confluence Server or Data Center instance running version ≥ 1.3.0 up to the fixed versions was exploitable by any network-reachable caller, authenticated or not.
+
+## Exploit
+
+Exploiting CVE-2022-26134 requires only a single crafted HTTP GET request. The OGNL payload is placed directly in the URI path and URL encoded so it passes through the HTTP layer cleanly:
+
+```
+GET /${(#a=@org.apache.commons.io.IOUtils@toString(
+    @java.lang.Runtime@getRuntime().exec("id")
+    .getInputStream(),"utf-8")).
+    (@com.opensymphony.webwork.ServletActionContext@getResponse()
+    .setHeader("X-Cmd-Response",#a))}/ HTTP/1.1
+Host: target.example.com:8090
+```
+
+When Confluence processes this request:
+
+1. The framework extracts the URI path as the action namespace.
+2. `ActionChainResult.execute()` calls `TextParseUtil.translateVariables()` on the namespace.
+3. `translateVariables()` detects the `${...}` wrapper and calls `OgnlValueStack.findValue()`.
+4. OGNL evaluates the expression: it obtains the JVM runtime via `@java.lang.Runtime@getRuntime()`, calls `exec("id")`, reads the output stream, and writes the result into a custom HTTP response header.
+5. The attacker reads the response header to get the output of the executed command.
+
+Because OGNL has unrestricted access to the Java classpath, attackers are not limited to simple commands. Real-world exploitation included deploying webshells, running reconnaissance commands (`whoami`, `ipconfig`, `systeminfo`), and executing Base64-encoded PowerShell payloads to download ransomware.
+
+The attack leaves minimal traces in standard application logs, making it difficult to detect. No account, session token, or prior knowledge of the target is needed.
+
+## Fix
+
+Atlassian released patched versions on 3 June 2022 by shipping a new JAR file, `xwork-1.0.3-atlassian-10.jar`, replacing the vulnerable `xwork-1.0.3.6.jar`. The patch makes two complementary changes:
+
+**Change 1 – Remove `TextParseUtil.translateVariables()` from `ActionChainResult.execute()`**
+
+The patched `ActionChainResult` no longer passes `namespace` through the OGNL expression evaluator. The namespace is now used directly from routing configuration, meaning attacker-supplied URI content can never reach `findValue()`:
+
+```
+fixed file: xwork-1.0.3-atlassian-10.jar
+          → com/opensymphony/xwork/ActionChainResult.java
+
+ public void execute(final ActionInvocation invocation) throws Exception {
+     if (this.namespace == null) {
+         this.namespace = invocation.getProxy().getNamespace();
+     }
+     final OgnlValueStack stack = ActionContext.getContext().getValueStack();
+
++    final String finalNamespace = this.namespace;
++    final String finalActionName = this.actionName;
+
+     if (this.isInChainHistory(finalNamespace, finalActionName)) {
+         throw new XworkException("infinite recursion detected");
+     }
+     ...
+ }
+```
+
+The `+` lines show that `namespace` and `actionName` are now assigned directly, with no expression evaluation involved.
+
+**Change 2 – Introduce `SafeExpressionUtil` in `OgnlValueStack`**
+
+As a defence-in-depth measure, the patched JAR introduces a `SafeExpressionUtil` class plugged into `OgnlValueStack.findValue()`. Before any expression is evaluated, it is checked against a safe allow-list:
+
+```
+fixed file: xwork-1.0.3-atlassian-10.jar
+          → com/opensymphony/xwork/util/OgnlValueStack.java
+
+ public Object findValue(String expr) {
++    try {
++        if (expr == null) return null;
++        if (!this.safeExpressionUtil.isSafeExpression(expr)) return null;
+         if (this.overrides != null && this.overrides.containsKey(expr))
+             return this.overrides.get(expr);
+         ...
++    } catch (Exception e) {
++        return null;
++    }
+ }
+```
+
+`SafeExpressionUtil.isSafeExpression()` blocks expressions that reference dangerous Java classes like `java.lang.Runtime`, `java.lang.ProcessBuilder`, and reflection APIs. Even if an OGNL expression somehow reached `findValue()`, it would be rejected before doing any harm.
+
+Change 1 eliminates the root cause by breaking the data-to-code pipeline. Change 2 acts as a safety net against similar injection paths elsewhere in the codebase.
+
+## Prevention
+
+CVE-2022-26134 was discovered by Volexity on 31 May 2022 during an active incident response meaning it had already been exploited in the wild before Atlassian even knew about it. By the time a patch ships, the damage is often already done. The real goal is to catch these vulnerabilities before they ever reach production.
+
+The following practices would have prevented this vulnerability or significantly reduced its impact:
+
+1. *Never evaluate user-supplied data as code (input validation and contextual encoding).* The most direct fix is to never pass user-controlled input to an expression evaluator. Any string from an HTTP request — URI segments, query parameters, headers, or body fields must be treated as untrusted data, not a template to evaluate. Developers should audit every call to APIs like `translateVariables()`, `findValue()`, and `Ognl.getValue()` and confirm no untrusted input can reach them. Where dynamic resolution is genuinely needed, the valid expressions should be defined at build time and selected via a safe key, not built from user input.
+
+2. *Apply the principle of least privilege to expression language contexts.* Even when an expression language is necessary, its evaluation context should be locked down to the minimum required capabilities. For OGNL, this means a sandbox or allow-list that blocks access to dangerous classes like `java.lang.Runtime`, `java.lang.ProcessBuilder`, and `java.lang.reflect.*`. Atlassian's `SafeExpressionUtil` added in the patch is exactly this kind of control. Many modern frameworks offer built-in sandboxing or SecurityManager integration for this purpose.
+
+3. *Use threat modelling to identify unauthenticated code paths.* The severity of CVE-2022-26134 is amplified because the vulnerable path needs no authentication at all. During design and review, teams should explicitly map every entry point reachable without a login and apply extra scrutiny to what runs in those paths. Static analysis tools like CodeQL and Semgrep can be configured to flag expression evaluation APIs reachable from unauthenticated HTTP entry points.
+
+4. *Perform focused manual code review on routing and result-handling components.* `ActionChainResult` is a framework-level class that touches every HTTP request. Routing and action-chaining code is high-risk because it processes raw request data before application-level validation even runs. Code reviews should specifically check how framework components handle namespace, URI, and action name fields, and verify none of these flow into an expression evaluator unchecked.
+
+5. *Adopt fuzz testing with output examination on all HTTP endpoints.* Standard positive-path testing would never catch CVE-2022-26134  the vulnerability only triggers on malformed, attacker-crafted input. Fuzzing with OGNL-aware payloads (strings containing `${`, `#`, `@`) across all endpoints, including unauthenticated ones, and watching responses for signs of expression evaluation (unexpected headers, OGNL class names in error traces) would surface this bug in testing instead of production.
+
+6. *Deploy a Web Application Firewall (WAF) with expression injection signatures.* A WAF with rules to detect OGNL, EL, and SpEL injection patterns in HTTP requests can block exploitation attempts even against unpatched servers. This is not a replacement for patching, but it is an important defence-in-depth layer especially during the gap between disclosure and patch deployment.
+
+7. *Treat expression language libraries as part of the trusted computing base.* Libraries like OGNL, Spring Expression Language (SpEL), and FreeMarker are powerful and dangerous when exposed to untrusted input. Teams should track CVEs for all expression language dependencies, apply updates promptly, and avoid unmaintained older versions. In Confluence's case the root vulnerability was in `xwork-1.0.3.6.jar`, a dependency with a prior history of similar injection issues (e.g., CVE-2021-26084).
+
+## Conclusion
+
+The root cause of CVE-2022-26134 was a single architectural mistake: user-controlled data from the HTTP request URI was passed unmodified to `TextParseUtil.translateVariables()`, which evaluated it as an OGNL expression. Because OGNL can invoke arbitrary Java methods via reflection, this gave any unauthenticated attacker full remote code execution on affected Confluence instances. The fix correctly separates data from code removing expression evaluation from the routing pipeline entirely and introducing a safe expression allow-list as a secondary control.
+
+## References
+
+Atlassian Security Advisory (2022-06-02): <https://confluence.atlassian.com/doc/confluence-security-advisory-2022-06-02-1130377146.html>
+
+CVE-2022-26134 NVD Entry: <https://nvd.nist.gov/vuln/detail/CVE-2022-26134>
+
+CWE-917 Entry: <https://cwe.mitre.org/data/definitions/917.html>
+
+Atlassian Jira Ticket CONFSERVER-79016: <https://jira.atlassian.com/browse/CONFSERVER-79016>
+
+Volexity Threat Research — Zero-Day Exploitation of Atlassian Confluence (2022-06-02): <https://www.volexity.com/blog/2022/06/02/zero-day-exploitation-of-atlassian-confluence/>
+
+Rapid7 Technical Analysis — Active Exploitation of Confluence CVE-2022-26134 (2022-06-02): <https://www.rapid7.com/blog/post/2022/06/02/active-exploitation-of-confluence-cve-2022-26134/>
+
+Datadog — The Confluence RCE Vulnerability: Overview, Detection, and Remediation: <https://www.datadoghq.com/blog/confluence-vulnerability-overview-and-remediation/>
+
+NetByteSec Technical Walkthrough — Confluence Pre-Auth RCE OGNL Injection: <https://notes.netbytesec.com/2022/06/confluence-pre-auth-rce-ognl-injection.html>
+
+## Contributions
+
+Created by Purna Adithya Akula (G01588237) and Veera Venkata Satya Siddhartha Gopalam (G01551529)  
+George Mason University — SWE 681, Spring 2026
+
+(C) 2026. This work is openly licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)


### PR DESCRIPTION
This document provides a detailed case study on the OGNL injection vulnerability in Atlassian Confluence, including its introduction, exploitation, and remediation steps.

Closes #78