### PR TITLE
Add case study: Code Injection in pymatgen (CWE-95, CVE-2024-23346)

### DIFF
--- a/python/secure-coding-case-study-cwe-95-cve-2024-23346.md
+++ b/python/secure-coding-case-study-cwe-95-cve-2024-23346.md
@@ -1,0 +1,235 @@
+# CODE INJECTION IN PYMATGEN
+
+## Introduction
+
+Scientific software often reads files that appear harmless because they contain measurements, formulas, or domain data. That assumption fails when a parser treats part of a file as executable code. If an attacker can place code inside a data file and the software later evaluates that text, the file stops being only data. It becomes a way to run commands on the machine that processes it.
+
+That is the mistake behind CVE-2024-23346 in pymatgen, an open-source Python library used in materials science. The vulnerable code parsed transformation strings from Crystallographic Information Files, or CIF files, by passing those strings into Python's `eval()` function. A CIF file is supposed to describe a crystal structure, not execute Python code. Because the parser crossed that boundary, a malicious CIF file could trigger arbitrary command execution. This type of weakness consistently ranks among the CWE Top 25 Most Dangerous Software Weaknesses.
+
+This case study explains the software, the weakness, the vulnerable code path, the exploit, the fix, and the practices that would have prevented the issue. The prevention section is the most important part: the lesson is not simply "be careful with `eval()`." The lesson is to build parser code so that untrusted input cannot reach general-purpose code execution in the first place.
+
+## Software
+
+**Name:** pymatgen, also known as Python Materials Genomics  
+**Language:** Python  
+**URL:** <https://github.com/materialsproject/pymatgen>
+
+## Weakness
+
+[CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code](https://cwe.mitre.org/data/definitions/95.html), also known as eval injection.
+
+Python's `eval()` function takes a string and evaluates it as Python code. That can be useful only when the string is fully controlled by the program and cannot be influenced by an attacker. It is unsafe when the string comes from a file, request, database field, or other external source. In that situation, the attacker is no longer supplying only data. The attacker may be supplying instructions for the interpreter to run.
+
+A common but unsafe pattern is to call `eval()` while trying to restrict built-in functions:
+
+```python
+result = eval(user_input, {"__builtins__": None}, {"a": 1, "b": 2})
+```
+
+This looks safer than an unrestricted `eval()` call because direct access to built-ins such as `__import__` is removed. However, this is not a reliable security boundary. Python objects expose runtime metadata through attributes such as `__class__`, `__bases__`, `__mro__`, and `__subclasses__()`. An attacker can use those attributes to traverse Python's object model, find useful internal classes, recover import behavior, and call operating-system functionality.
+
+The secure design rule is narrower and stronger: parser code should not pass attacker-controlled strings to `eval()` or `exec()`. If a feature needs mathematical expressions, it should parse a small mathematical language. If it needs structured values, it should parse structured values. It should not invoke the Python interpreter on external text.
+
+## Vulnerability
+
+[CVE-2024-23346](https://www.cve.org/CVERecord?id=CVE-2024-23346) – Published 21 February 2024
+
+pymatgen, short for Python Materials Genomics, is a Python library for materials analysis. Researchers use it to work with crystal structures, phase diagrams, electronic structure calculations, and related materials science data. One file format it supports is the Crystallographic Information File format. CIF files are plain-text files used to describe crystal structures, including unit cell dimensions, atom positions, and symmetry information. In normal use, these files are exchanged between researchers, downloaded from public databases, and uploaded into analysis tools. That workflow matters for security: a CIF parser is not only a convenience feature but an input boundary, and any library that reads CIF files may eventually process files supplied by untrusted sources.
+
+The GitHub security advisory lists affected versions as `<= 2024.2.8` and the patched version as `2024.2.20`. Users should upgrade to pymatgen `2024.2.20` or later.
+
+The vulnerable code was in the logic used by `JonesFaithfulTransformation` to parse transformation strings. A transformation string describes how crystal basis vectors and origin shifts should be changed. A normal string looks like this:
+
+```text
+a,b,c;0,0,0
+```
+
+The part before the semicolon describes the basis change. The part after the semicolon describes the origin shift. In this example, the basis vectors remain unchanged and the origin shift is zero.
+
+The vulnerable method split the input into those parts, split the basis expression into three separate components, performed a regular-expression substitution to add implicit multiplication symbols, and then evaluated each component with `eval()`.
+
+```python
+vulnerable file: pymatgen/symmetry/settings.py
+
+  97    @staticmethod
+  98    def parse_transformation_string(
+  99        transformation_string: str = "a,b,c;0,0,0",
+ 100    ) -> tuple[list[list[float]], list[float]]:
+ 101        try:
+ 102            b_change, o_shift = transformation_string.split(";")
+ 103            basis_change = b_change.split(",")
+ 104            origin_shift = o_shift.split(",")
+ 105            # add implicit multiplication symbols
+ 106            basis_change = [
+ 107                re.sub(
+ 108                    r"(?<=\w|\))(?=\() | (?<=\))(?=\w) | (?<=(\d|a|b|c))(?=([abc]))",
+ 109                    r"*",
+ 110                    string,
+ 111                    flags=re.X,
+ 112                )
+ 113                for string in basis_change
+ 114            ]
+ 115            # should be fine to use eval here but be mindful for security
+ 116            # reasons
+ 117            # see http://lybniz2.sourceforge.net/safeeval.html
+ 118            # could replace with regex? or sympy expression?
+ 119            P = np.array(
+ 120                [eval(x, {"__builtins__": None}, {"a": a, "b": b, "c": c})
+ 121                 for x in basis_change]
+ 122            )
+ 123            P = P.transpose()  # by convention
+```
+
+The dangerous operation is line 120. Each string in `basis_change` is evaluated as Python code. The regular expression at lines 106 through 114 only adjusts syntax by inserting multiplication symbols. It does not prove that the expression is a valid crystallographic transformation. It does not restrict the input to a formal grammar. It does not prevent Python object traversal. The data therefore moves from a CIF-controlled field to a code-execution sink.
+
+The source comment at lines 115 through 118 is also important. The comment shows that the risk was visible during development. It says to be mindful of security and mentions replacing `eval()` with a regular expression or Sympy expression. The vulnerability remained because the dangerous call stayed in the parser. Awareness was not enough; the code needed a rule, test, and review process that prevented unsafe dynamic evaluation in file-parsing logic.
+
+## Exploit
+
+[CAPEC-242: Code Injection](https://capec.mitre.org/data/definitions/242.html)
+
+An attacker could exploit this vulnerability by creating a CIF file whose symmetry transformation field contains Python code instead of an ordinary mathematical transformation. The attacker would not need to modify pymatgen. The attacker would only need the victim, or a server used by the victim, to parse the malicious CIF file with a vulnerable version of the library.
+
+A simplified malicious CIF fragment could look like this:
+
+```text
+data_exploit
+_cell_length_a                  5.0
+_cell_length_b                  5.0
+_cell_length_c                  5.0
+_cell_angle_alpha               90
+_cell_angle_beta                90
+_cell_angle_gamma               90
+_symmetry_equiv_pos_as_xyz
+'[x for x in ().__class__.__bases__[0].__subclasses__()
+ if x.__name__=="BuiltinImporter"][0]().load_module("os")
+ .system("id"),b,c;0,0,0'
+```
+
+When a vulnerable parser processes the transformation string, the expression before the semicolon can become part of `basis_change`. At the vulnerable line, pymatgen passes that expression to `eval()`. The expression walks through Python's class hierarchy, finds `BuiltinImporter`, loads the `os` module, and calls `os.system("id")`.
+
+The `id` command is only a proof of execution. A real attacker could replace it with a command that reads files, downloads a payload, modifies data, or opens a reverse shell.
+
+The practical impact depends on where pymatgen is running. On a researcher's workstation, the command would run with that user's privileges. On a web service that accepts CIF uploads, the command could run on the server that processes uploaded files. This is what makes the bug serious: the attacker uses something that looks like scientific data to reach Python code execution.
+
+## Fix
+
+The issue was fixed in pymatgen version `2024.2.20`. The relevant patch removed `eval()` from the transformation parsing path and replaced it with a narrower parsing approach. The fix added Sympy support and parsed the transformation as symbolic mathematics instead of Python code.
+
+The patch added these imports:
+
+```diff
+fixed file: pymatgen/symmetry/settings.py
+
++  9    from sympy import Matrix
++ 10    from sympy.parsing.sympy_parser import parse_expr
+```
+
+The old `eval()` logic was replaced with character filtering and symbolic parsing:
+
+```diff
+fixed file: pymatgen/symmetry/settings.py
+
+ 106            basis_change = [
+ 107                re.sub(
+ 108                    r"(?<=\w|\))(?=\() | (?<=\))(?=\w) | (?<=(\d|a|b|c))(?=([abc]))",
+ 109                    r"*",
+ 110                    string,
+ 111                    flags=re.X,
+ 112                )
+ 113                for string in basis_change
+ 114            ]
++115
++116            # basic input sanitation
++117            allowed_chars = "0123456789+-*/.abc()"
++118            basis_change = [
++119                "".join([c for c in string if c in allowed_chars])
++120                for string in basis_change
++121            ]
++122
++123            # requires round-trip to sympy to evaluate
++124            basis_change = [
++125                parse_expr(string).subs({"a": Matrix(a), "b": Matrix(b), "c": Matrix(c)})
++126                for string in basis_change
++127            ]
++128            P = np.array(basis_change, dtype=float).T[0]
+-119            P = np.array(
+-120                [eval(x, {"__builtins__": None}, {"a": a, "b": b, "c": c})
+-121                 for x in basis_change]
+-122            )
+-123            P = P.transpose()  # by convention
+```
+
+This fix improves the design because it removes general-purpose Python evaluation from a file parser. The allowed character set keeps the input close to the expected mathematical language: digits, arithmetic operators, a decimal point, parentheses, and the variables `a`, `b`, and `c`. Characters needed for the exploit, including underscores, quotes, brackets, and longer names, are blocked from reaching the symbolic parser.
+
+The call to `parse_expr()` then treats the input as symbolic mathematics. The variables `a`, `b`, and `c` are substituted with matrix values, and the result is converted into the NumPy representation expected by the rest of pymatgen. The feature still supports normal transformation strings, but it no longer sends CIF-controlled text directly to the Python interpreter.
+
+The patch is a major improvement, but the strongest general pattern is to fail closed. New parser code should reject invalid characters or invalid grammar with a clear error instead of silently removing unexpected characters. Rejection makes malformed input visible, prevents accidental reinterpretation, and gives maintainers a better signal when someone is probing the parser.
+
+## Prevention
+
+The most important prevention is a project rule that forbids `eval()` and `exec()` on any path reachable from external input. This rule must be enforced by tooling, not left as advice in a comment. In pymatgen, the vulnerable source comment already showed that the risk was known. The failure was not a lack of awareness. The failure was allowing known-risk code to remain in a parser.
+
+A practical policy for a Python project would be to run Bandit in continuous integration and fail the build when Bandit reports B307, the rule for `eval()`. For parser code, that failure should almost never be waived. If a maintainer believes an exception is necessary, the exception should require a written justification explaining why the input is not attacker-controlled, what grammar is accepted, and what tests prove the behavior is safe. This would have forced the vulnerable line in `settings.py` to be reviewed before release instead of being left behind with a cautionary comment.
+
+The parser should also be designed around the smallest language the feature actually needs. The transformation string in this case needed arithmetic over three variables. It did not need imports, attribute access, list comprehensions, function calls, subclass traversal, or access to Python's runtime object model. That difference should drive the implementation. A small parser, a parser-combinator grammar, or a symbolic math parser constrained to the expected operations is safer than evaluating Python code and trying to remove dangerous pieces afterward.
+
+Input validation should use allowlists and should fail closed. A denylist asks, "Which dangerous strings should we block?" That question is fragile because attackers can often express the same behavior in another way. An allowlist asks, "What exact tokens are valid for this field?" For this transformation field, valid tokens are limited: numbers, arithmetic operators, parentheses, separators, and the variables representing basis vectors. Anything outside that grammar should produce an error. Invalid CIF data should not be cleaned into a different expression without warning.
+
+A safer parser could enforce this idea directly. For example, the parser could check each expression against a grammar equivalent to this policy:
+
+```text
+expression  = term (("+" | "-") term)*
+term        = factor (("*" | "/") factor)*
+factor      = number | "a" | "b" | "c" | "(" expression ")"
+```
+
+That grammar allows the mathematical transformations the feature needs, but it has no syntax for imports, attributes, strings, lists, function calls, or object traversal. A developer reviewing that grammar can reason about what the parser accepts. That is much safer than trying to reason about every behavior the Python interpreter might allow.
+
+Testing should include hostile parser inputs, not only valid scientific examples. A secure test suite for this parser should include a CIF file with Python attribute access, a CIF file with quotes and brackets, a CIF file with shell metacharacters, a very long transformation string, null bytes, unexpected Unicode, and malformed separator placement. The test should assert that the parser rejects the input and does not create a subprocess, write a file, import a module, or call an operating-system function. A regression test for CVE-2024-23346 should specifically include the `BuiltinImporter` style payload and verify that it is rejected.
+
+Fuzzing would also help because file parsers often fail in unusual combinations of syntax. Atheris, a Python fuzzing framework, could generate many transformation strings and run them through the parser while checking that the parser either returns a valid mathematical result or raises a controlled exception. The important security property is not only "the parser does not crash." For this bug, the property is "the parser never reaches dangerous sinks such as `eval()`, `exec()`, `subprocess`, or `os.system()` with file-controlled data."
+
+Code review should include a source-to-sink check for file parsers. Reviewers should identify where external data enters the program, how that data is validated, and whether it reaches dangerous operations. In this case, the source was a CIF transformation field and the sink was `eval()`. A review checklist that explicitly asks for source-to-sink paths would have exposed the issue quickly.
+
+Dependency management is also part of prevention for users of the library. Projects that use pymatgen should pin dependencies, monitor vulnerability advisories, and upgrade when a security release is published. For this vulnerability, the correct user-side mitigation is to upgrade to pymatgen `2024.2.20` or later. If a service must process untrusted CIF files, the service should also isolate parsing in a restricted environment with least privilege. Sandboxing is not a replacement for fixing the parser, but it reduces impact if another parser bug is discovered later.
+
+The general lesson is that parser security needs systematic controls. A warning comment is weak. A secure design uses a narrow grammar, rejects invalid input, blocks dangerous APIs in CI, tests hostile inputs, reviews source-to-sink data flow, and limits runtime privileges. Those measures are practical, repeatable, and directly targeted at the coding mistake that caused CVE-2024-23346.
+
+## Conclusion
+
+CVE-2024-23346 happened because pymatgen allowed data from a CIF file to reach Python's `eval()` function while parsing symmetry transformation strings. The parser expected a small mathematical expression, but it used a mechanism powerful enough to execute arbitrary Python code. Disabling built-ins did not make the design safe because Python's object model still allowed an attacker to recover dangerous capabilities.
+
+The fix removed `eval()` and moved the parser toward a narrower symbolic-math design. The broader lesson is that external data should be parsed as data, not executed as code. Software that processes scientific files should define the smallest language it accepts, reject anything outside that language, use tools that cannot execute general-purpose code, enforce dangerous-API checks in CI, and test parsers with hostile inputs.
+
+## References
+
+pymatgen Project Page: <https://github.com/materialsproject/pymatgen>
+
+CVE-2024-23346 Entry: <https://www.cve.org/CVERecord?id=CVE-2024-23346>
+
+CWE-95 Entry: <https://cwe.mitre.org/data/definitions/95.html>
+
+CAPEC-242 Entry: <https://capec.mitre.org/data/definitions/242.html>
+
+NVD Vulnerability Report: <https://nvd.nist.gov/vuln/detail/CVE-2024-23346>
+
+GitHub Advisory GHSA-vgv8-5cpj-qj2f: <https://github.com/advisories/GHSA-vgv8-5cpj-qj2f>
+
+pymatgen Security Advisory: <https://github.com/materialsproject/pymatgen/security/advisories/GHSA-vgv8-5cpj-qj2f>
+
+pymatgen Fix Commit: <https://github.com/materialsproject/pymatgen/commit/c231cbd3d5147ee920a37b6ee9dd236b376bcf5a>
+
+Vulnerable Source File – pymatgen/symmetry/settings.py: <https://github.com/materialsproject/pymatgen/blob/master/pymatgen/symmetry/settings.py>
+
+Bandit Python Security Linter – B307 eval Rule: <https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html>
+
+Sympy parse_expr Documentation: <https://docs.sympy.org/latest/modules/parsing.html>
+
+Atheris Python Fuzzing Framework: <https://github.com/google/atheris>
+
+## Contributions
+
+Originally created by Bhanu Prakash Reddy Ramidi - George Mason University  
+Originally created by Samay Salveru - George Mason University  
+This work is openly licensed under CC-BY-4.0.


### PR DESCRIPTION
This case study covers CVE-2024-23346, an eval injection vulnerability 
in pymatgen's CIF file parser (CWE-95).

Authors: Bhanu Prakash Reddy Ramidi and Samay Salveru
Institution: George Mason University
License: CC-BY-4.0