### PR TITLE
Add CVE-2024-34359 vulnerability documentation

### DIFF
--- a/python/CVE-2024-34359.md
+++ b/python/CVE-2024-34359.md
@@ -1,0 +1,128 @@
+# SERVER-SIDE TEMPLATE INJECTION IN LLAMA-CPP-PYTHON
+
+## Introduction
+
+CVE-2024-34359 is a server-side template injection vulnerability in `llama-cpp-python`, a Python binding and high-level interface for running `llama.cpp` models. The GitHub security advisory `GHSA-56xg-wfcc-g829` marks affected versions as `>= v0.2.30, <= v0.2.71` and lists `>= v0.2.72` as patched. NVD records a CNA-provided CVSS v3.1 base score of 9.6 and rates the issue Critical. ([github.com](https://github.com/abetlen/llama-cpp-python/security/advisories/GHSA-56xg-wfcc-g829))
+
+The vulnerability arose because externally supplied model metadata could be treated as Jinja2 template source and then rendered during chat prompt construction. In practice, that meant a malicious `.gguf` model file could carry a hostile chat template that the library would compile and evaluate on the server side. This is exactly the kind of mistake secure coding guidance warns about: software crossed a trust boundary but still handled the incoming content as though it were application-authored logic. ([github.com](https://github.com/abetlen/llama-cpp-python/security/advisories/GHSA-56xg-wfcc-g829))
+
+This case study focuses less on the historical timeline and more on the design lesson. The important question is not merely why this one library was vulnerable, but what engineering choices would have made the bug unlikely or impossible in the first place. That is why the Prevention section emphasizes trust boundaries, safe rendering design, sandboxing, hostile testing, and third-party artifact policy rather than generic advice to “validate input.” ([cwe.mitre.org](https://cwe.mitre.org/data/definitions/1336.html))
+
+## Software
+
+`llama-cpp-python` is the Python package that exposes `llama.cpp` functionality to Python applications. The vulnerable behavior affected the package `llama_cpp_python` and specifically its chat formatting path, which used Jinja2 templates to turn structured chat messages into the final prompt text expected by a model. The advisory describes the package, the affected versions, and the model-loading path that pulled chat-template data from `.gguf` metadata. ([github.com](https://github.com/abetlen/llama-cpp-python/security/advisories/GHSA-56xg-wfcc-g829))
+
+The relevant implementation lived in `llama_cpp/llama_chat_format.py`. In the vulnerable release, that file defined `Jinja2ChatFormatter`, accepted a template string, compiled it with Jinja2, and later rendered it with runtime chat data. The same file also contained logic that recognized the `tokenizer.chat_template` metadata key, showing that chat-template metadata was a first-class part of the package’s model-formatting design. ([github.com](https://github.com/abetlen/llama-cpp-python/blob/v0.2.71/llama_cpp/llama_chat_format.py))
+
+## Weakness
+
+The weakness class at issue is improper neutralization of special elements in a template engine, catalogued as CWE-1336. A template engine renders a template, which is a string containing literal text together with expressions or directives, against a data context. When the application authors the template and only outside data is inserted into predefined placeholders, the engine behaves like a formatting tool. When untrusted input is allowed to become the template source itself, the engine instead interprets attacker-controlled syntax as template expressions or directives. CWE-1336 captures that failure mode directly. ([cwe.mitre.org](https://cwe.mitre.org/data/definitions/1336.html))
+
+Two CWE identifiers are relevant here, and the distinction should be stated explicitly. NVD and the GitHub advisory record this CVE under CWE-76, “Improper Neutralization of Equivalent Special Elements,” which is a broader entry. This case study instead uses CWE-1336 because it is more precise for template injection: the problem was not merely that special characters were mishandled in the abstract, but that externally influenced input was passed into a template engine and interpreted as executable template syntax. That narrower classification better names the technical mistake discussed in this essay. ([github.com](https://github.com/abetlen/llama-cpp-python/security/advisories/GHSA-56xg-wfcc-g829))
+
+Server-side template injection occurs when attacker-controlled input is treated as template code instead of inert data. PortSwigger’s SSTI research describes this class of vulnerability as server-side evaluation of malicious template syntax, often with the goal of reaching arbitrary code execution. Jinja’s own documentation reflects the same risk model by providing a sandboxed environment for untrusted templates and by explaining that the sandboxed compiler and runtime can restrict unsafe attribute access and function use. ([portswigger.net](https://portswigger.net/research/server-side-template-injection))
+
+The secure-design lesson is direct. If template source is not fully trusted, the application must not render it in a normal environment. At that point the software is no longer substituting data into a fixed format; it is allowing an external party to supply code for an interpreter. That is the architectural failure CWE-1336 exists to describe. ([cwe.mitre.org](https://cwe.mitre.org/data/definitions/1336.html))
+
+## Vulnerability
+
+In `llama-cpp-python` versions `0.2.30` through `0.2.71`, the vulnerable path centered on `llama_cpp/llama_chat_format.py`, where chat-template text was compiled and later rendered by Jinja2. The advisory explains that the higher-level `Llama` loading path pulled the chat template from `.gguf` metadata and passed it into `llama_chat_format.Jinja2ChatFormatter`, ultimately constructing the model’s chat handler from that metadata. ([github.com](https://github.com/abetlen/llama-cpp-python/security/advisories/GHSA-56xg-wfcc-g829))
+
+The exposure became concrete in `Jinja2ChatFormatter.__init__`, where the incoming template string was compiled with a normal Jinja2 environment:
+
+```python
+# vulnerable file: llama_cpp/llama_chat_format.py (v0.2.71)
+self.template = template
+self._environment = jinja2.Environment(
+    loader=jinja2.BaseLoader(),
+    trim_blocks=True,
+    lstrip_blocks=True,
+).from_string(self.template)
+```
+
+This code mattered because it treated externally supplied template content as executable template source. The vulnerable release did not use Jinja’s sandboxed environment even though Jinja documents sandboxing as the mechanism for rendering untrusted templates more safely. ([github.com](https://github.com/abetlen/llama-cpp-python/blob/v0.2.71/llama_cpp/llama_chat_format.py))
+
+Compilation alone did not trigger the payload. Execution occurred later when the formatter rendered the compiled template against runtime chat data:
+
+```python
+# vulnerable file: llama_cpp/llama_chat_format.py (v0.2.71)
+prompt = self._environment.render(
+    messages=messages,
+    eos_token=self.eos_token,
+    bos_token=self.bos_token,
+    raise_exception=raise_exception,
+    add_generation_prompt=self.add_generation_prompt,
+    functions=functions,
+    function_call=function_call,
+    tools=tools,
+    tool_choice=tool_choice,
+)
+```
+
+At that point, any attacker-controlled Jinja2 expressions embedded in the template body were evaluated on the server side during prompt construction. The trust-boundary violation was therefore simple and serious: a model artifact supplied from outside the application was allowed to define interpreter-readable template logic, and the library then executed that logic as part of normal program flow. ([github.com](https://github.com/abetlen/llama-cpp-python/blob/v0.2.71/llama_cpp/llama_chat_format.py))
+
+## Exploit
+
+The exploit path followed directly from the design. An attacker who could influence which `.gguf` file the application loaded could embed a malicious `tokenizer.chat_template` inside that model’s metadata. The advisory states that the `Llama` loading path read that metadata and forwarded it into `Jinja2ChatFormatter`, after which the formatter compiled and rendered it. That gave the attacker control over the template source rather than merely the values inserted into a trusted template. ([github.com](https://github.com/abetlen/llama-cpp-python/security/advisories/GHSA-56xg-wfcc-g829))
+
+That distinction is what makes SSTI dangerous. PortSwigger’s research explains that template injection is especially severe when input reaches the engine as code, because the attacker is no longer limited to corrupting output format; they are interacting with a server-side interpreter. In this case the advisory explicitly states that the result was remote code execution through a carefully constructed payload. The underlying issue was not a malformed prompt string but a hostile template executed during prompt generation. ([portswigger.net](https://portswigger.net/research/server-side-template-injection))
+
+The practical exploitation scenario is easy to understand even without reproducing a payload. A developer or application loads a third-party model file, the library reads its metadata, and prompt rendering later evaluates template expressions that came from that file. No separate “plugin install” or code deployment step is needed, because the dangerous logic is smuggled inside a field the program already expects to consume. That is why this case is a useful teaching example: the exploit path hides inside normal configuration and model-loading behavior. ([github.com](https://github.com/abetlen/llama-cpp-python/security/advisories/GHSA-56xg-wfcc-g829))
+
+## Fix
+
+The project fixed the vulnerability in commit `b454f40a9a1787b2b5659cd2cb00819d983185df`, which is also referenced by NVD. The key code change was to replace the normal Jinja2 environment with `ImmutableSandboxedEnvironment`, and the patch also added the corresponding import from `jinja2.sandbox`. ([nvd.nist.gov](https://nvd.nist.gov/vuln/detail/CVE-2024-34359))
+
+Before the patch, the formatter used `jinja2.Environment(...).from_string(self.template)`. After the patch, the corresponding code became:
+
+```python
+# fixed file: llama_cpp/llama_chat_format.py (commit b454f40)
+from jinja2.sandbox import ImmutableSandboxedEnvironment
+
+self._environment = ImmutableSandboxedEnvironment(
+    loader=jinja2.BaseLoader(),
+    trim_blocks=True,
+    lstrip_blocks=True,
+).from_string(self.template)
+```
+
+Jinja’s documentation says the sandboxed environment works like the regular environment but generates sandboxed code and can block access to unsafe attributes and functions, raising `SecurityError` when a template tries to access insecure code. That is the security property the vulnerable version lacked. ([github.com](https://github.com/abetlen/llama-cpp-python/blob/b454f40a9a1787b2b5659cd2cb00819d983185df/llama_cpp/llama_chat_format.py))
+
+The patch mitigated the exploit path by ensuring that externally supplied template content was no longer compiled in a normal, unrestricted environment. The render step still existed, but it now ran inside Jinja’s protection boundary instead of the general environment used by the vulnerable version. That was an appropriate and targeted fix because it addressed the precise design error that made the metadata field dangerous. ([github.com](https://github.com/abetlen/llama-cpp-python/blob/b454f40a9a1787b2b5659cd2cb00819d983185df/llama_cpp/llama_chat_format.py))
+
+At the same time, the fix should not be misread as permission to treat third-party model metadata as fully trusted code. Sandboxing is a containment measure, not proof that external artifacts are harmless. The broader engineering lesson is that software should be designed so that third-party configuration and model metadata are not granted interpreter-level authority unless that capability is both intentional and strongly constrained. ([jinja.palletsprojects.com](https://jinja.palletsprojects.com/en/stable/sandbox/))
+
+## Prevention
+
+The first preventative step that must be taken is the correct identification of the trust boundary. The problem here is that a `.gguf` file obtained through a registry, repository, or from some other specified source by the user is more than just "data" – the application is expecting to read and execute information. In this instance, the model contained a field called `tokenizer.chat_template`, which can clearly be seen as code. The secure design review should have therefore recognized model metadata as external influencing data and asked whether any of those fields crossed into the realm of code?([github.com](https://github.com/abetlen/llama-cpp-python/security/advisories/GHSA-56xg-wfcc-g829))
+
+The second mitigation technique is safer rendering design. External templates must be regarded as data unless there is a clear need for them to be executable within the product specification. To mitigate the risks involved with the chat formatting feature mentioned above, it is best to implement a design that does not allow for free execution of templates supplied by the metadata. There could be many designs available for the software that will mitigate the risks. It could use an internal schema with a limited set of allowed formatting actions, or a parser that will transform the approved templates into some other form. ([cwe.mitre.org](https://cwe.mitre.org/data/definitions/1336.html))
+
+The third way to deal with this problem is by applying sandboxing and related constraints when template evaluation cannot be avoided. As mentioned above, mitigation advice provided with CWE-1336 clearly suggests using a sandbox or a restricted version of the selected template engine. Moreover, Jinja provides details on using `SandboxedEnvironment`, which will be useful precisely because it protects users from accessing insecure code paths. In our situation, picking sandbox from the very beginning may not guarantee complete safety but at least will limit potential threats posed by harmful metadata reaching dangerous objects. ([cwe.mitre.org](https://cwe.mitre.org/data/definitions/1336.html))
+
+The fourth test is hostile security testing. The conventional set of functional tests will probably just verify that the most typical chat templates can be rendered properly. This isn’t sufficient. If any piece of software is responsible for rendering externally supplied templates, then there must be negative tests involving malicious code snippets, regression tests ensuring that sandbox breaches trigger errors rather than execute, and review checklists searching out `from_string(...)`, unsanitized environment creation, or any route that might turn an external variable into interpreter code. It’s helpful to keep in mind that PortSwigger’s SSTI research demonstrates the need to consider template injection as an interpreter issue, rather than verifying output correctness. ([portswigger.net](https://portswigger.net/research/server-side-template-injection))
+
+The fifth control involves the release and ingestion strategy for external artifacts. If an application relies on loading models, plugins, workflow configurations, or any other kind of asset created by a third party, it should clearly specify which metadata entries are inactive, which are active, and what kinds of protections surround each entry. The security analysis of the code that loads artifacts must be made compulsory if any metadata entry impacts the program flow, prompting generation, or evaluation processes. It would certainly not eliminate the need for writing robust code, but it would help minimize the risk of loading a malicious artifact into a high-privilege runtime environment in the first place. ([github.com](https://github.com/abetlen/llama-cpp-python/security/advisories/GHSA-56xg-wfcc-g829))
+
+All of these controls represent systemic preventative measures. The correct labeling of the trust boundary would have alerted the developer of the potential risk. The safer rendering design would have minimized interpreter invocation. Sandboxing would have helped limit the scope in case there were any rendering. Threat modeling and hostile testing would have detected the vulnerable function `Environment(...).from_string(...)`. Artifact-ingestion policy would have provided another level of defense. This is what the standard secure programming technique for such a situation would involve – making sure no artifact gets execution capabilities from outside the system. ([github.com](https://github.com/abetlen/llama-cpp-python/blob/v0.2.71/llama_cpp/llama_chat_format.py))
+
+## Conclusion
+
+CVE-2024-34359 is a strong example of why template engines must be treated as interpreters, not string-formatting conveniences. `llama-cpp-python` accepted externally supplied chat-template content from model metadata, compiled it in a normal Jinja2 environment, and later executed it during prompt construction. The patch correctly moved that execution into `ImmutableSandboxedEnvironment`, but the deeper lesson is architectural: once external input becomes template source, the system has crossed from data handling into code execution. ([github.com](https://github.com/abetlen/llama-cpp-python/security/advisories/GHSA-56xg-wfcc-g829))
+
+The case also shows why prevention guidance must be concrete. “Validate input” would not have been enough unless it meant something specific, such as forbidding free-form external template execution, using a sandbox, adding malicious-template regression tests, and treating model metadata as an untrusted artifact class. Those controls are actionable, reviewable, and directly connected to the way this vulnerability arose. That is what makes them useful secure-coding guidance rather than hindsight. ([cwe.mitre.org](https://cwe.mitre.org/data/definitions/1336.html))
+
+## References
+
+- MITRE Secure Coding Case Studies Style Guide. ([raw.githubusercontent.com](https://raw.githubusercontent.com/mitre/secure-coding-case-studies/main/STYLE_GUIDE.md))
+- GitHub Security Advisory `GHSA-56xg-wfcc-g829`, “Remote Code Execution by Server-Side Template Injection in Model Metadata.” ([github.com](https://github.com/abetlen/llama-cpp-python/security/advisories/GHSA-56xg-wfcc-g829))
+- NVD entry for `CVE-2024-34359`. ([nvd.nist.gov](https://nvd.nist.gov/vuln/detail/CVE-2024-34359))
+- Vulnerable source file: `llama_cpp/llama_chat_format.py` at tag `v0.2.71`. ([github.com](https://github.com/abetlen/llama-cpp-python/blob/v0.2.71/llama_cpp/llama_chat_format.py))
+- Fix commit `b454f40a9a1787b2b5659cd2cb00819d983185df` and fixed source file. ([github.com](https://github.com/abetlen/llama-cpp-python/blob/b454f40a9a1787b2b5659cd2cb00819d983185df/llama_cpp/llama_chat_format.py))
+- CWE-1336: Improper Neutralization of Special Elements Used in a Template Engine. ([cwe.mitre.org](https://cwe.mitre.org/data/definitions/1336.html))
+- Jinja Documentation: Sandbox. ([jinja.palletsprojects.com](https://jinja.palletsprojects.com/en/stable/sandbox/))
+- PortSwigger Research: Server-Side Template Injection. ([portswigger.net](https://portswigger.net/research/server-side-template-injection))
+
+## Contributions
+
+- Author: Pranav Goriparthi


### PR DESCRIPTION
Document the server-side template injection vulnerability CVE-2024-34359 in llama-cpp-python, detailing its impact, exploit path, and mitigation strategies.